### PR TITLE
Dynamic Org Lifecycle — Hiring, Firing & Backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,122 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [v0.3.0] — 2026-03-04
+
+### Added
+
+- **`org_lifecycle.py` — `OrgLifecycleManager`** — new module that owns all
+  dynamic roster mutations. The engine controls every side-effect; LLMs only
+  produce narrative prose after the fact. Three public entry points called from
+  `flow.py` before planning runs each day:
+  - `process_departures()` — fires scheduled departures and optional random
+    attrition; executes three deterministic side-effects in strict order before
+    removing the node (see below)
+  - `process_hires()` — adds new engineer nodes at `edge_weight_floor` with
+    cold-start edges, bootstraps a persona, and emits an `employee_hired` SimEvent
+  - `scan_for_knowledge_gaps()` — scans any free text (incident root cause,
+    Confluence body) against all departed employees' `knowledge_domains` and
+    emits a `knowledge_gap_detected` SimEvent on first hit per domain; deduplicates
+    across the full simulation run
+  - `get_roster_context()` — compact string injected into `DepartmentPlanner`
+    prompts so the LLM naturally proposes `warmup_1on1` and `onboarding_session`
+    events for new hires and references recent departures by name
+    _File: `org_lifecycle.py` (new)_
+
+- **Departure side-effect 1 — Active incident handoff** — before the departing
+  node is removed, every active incident whose linked JIRA ticket is assigned to
+  that engineer triggers a Dijkstra escalation chain while the node is still
+  present. Ownership transfers to the first non-departing person in the chain,
+  falling back to the dept lead if no path exists. The JIRA `assignee` field is
+  mutated deterministically; an `escalation_chain` SimEvent with
+  `trigger: "forced_handoff_on_departure"` is emitted.
+  _File: `org_lifecycle.py` — `OrgLifecycleManager._handoff_active_incidents()`_
+
+- **Departure side-effect 2 — JIRA ticket reassignment** — all non-Done tickets
+  owned by the departing engineer are reassigned to the dept lead. Status logic:
+  `"To Do"` tickets keep their status; `"In Progress"` tickets with no linked PR
+  are reset to `"To Do"` so the new owner starts fresh; `"In Progress"` tickets
+  with a linked PR retain their status so the existing PR review/merge flow closes
+  them naturally. Tickets already handled by the incident handoff are not
+  double-logged. Each reassignment emits a `ticket_progress` SimEvent with
+  `reason: "departure_reassignment"`.
+  _File: `org_lifecycle.py` — `OrgLifecycleManager._reassign_jira_tickets()`_
+
+- **Departure side-effect 3 — Centrality vacuum stress** — after the node is
+  removed, betweenness centrality is recomputed on the smaller graph and diffed
+  against the pre-departure snapshot. Nodes whose score increased have absorbed
+  bridging load; each receives `stress_delta = Δc × multiplier` (default `40`,
+  configurable via `centrality_vacuum_stress_multiplier`, hard-capped at 20 points
+  per departure). This reflects the real phenomenon where a connector's departure
+  leaves adjacent nodes as sole bridges across previously-separate clusters.
+  _File: `org_lifecycle.py` — `OrgLifecycleManager._apply_centrality_vacuum()`_
+
+- **New hire cold-start edges** — hired engineers enter the graph with edges at
+  `edge_weight_floor` to cross-dept nodes and `floor × 2` to same-dept peers.
+  Both values sit below `warmup_threshold` (default `2.0`) so `DepartmentPlanner`
+  will propose `warmup_1on1` and `onboarding_session` events organically until
+  enough collaboration has occurred to warm the edges past the threshold.
+  `OrgLifecycleManager.warm_up_edge()` is called from `flow.py` whenever one of
+  those events fires.
+  _File: `org_lifecycle.py` — `OrgLifecycleManager._execute_hire()`_
+
+- **`patch_validator_for_lifecycle()`** — call once per day after
+  `process_departures()` / `process_hires()` to prune departed names from
+  `PlanValidator._valid_actors` and add new hire names. Keeps the actor integrity
+  check honest without rebuilding the validator from scratch each day.
+  _File: `org_lifecycle.py`_
+
+- **`recompute_escalation_after_departure()`** — thin wrapper called from
+  `flow.py._end_of_day()` that rebuilds the escalation chain from the dept's
+  remaining first responder after the departed node has been removed. Logs the
+  updated path as an `escalation_chain` SimEvent for ground-truth retrieval.
+  _File: `org_lifecycle.py`_
+
+- **New `KNOWN_EVENT_TYPES`** — `employee_departed`, `employee_hired`,
+  `knowledge_gap_detected`, `onboarding_session`, `farewell_message`,
+  `warmup_1on1` added to the validator vocabulary so the planner can propose
+  them without triggering the novel event fallback path.
+  _File: `planner_models.py`_
+
+- **New `State` fields** — `departed_employees: Dict[str, Dict]` and
+  `new_hires: Dict[str, Dict]` added to track dynamic roster changes across
+  the simulation; both are populated by `OrgLifecycleManager` and included in
+  `simulation_snapshot.json` at EOD.
+  _File: `flow.py` — `State`_
+
+- **`simulation_snapshot.json` lifecycle sections** — `departed_employees`,
+  `new_hires`, and `knowledge_gap_events` arrays appended to the final snapshot
+  so the full roster history is available alongside relationship and stress data.
+  _File: `flow.py` — `Flow._print_final_report()`_
+
+- **`org_lifecycle` config block** — new top-level config section supports
+  `scheduled_departures`, `scheduled_hires`, `enable_random_attrition`, and
+  `random_attrition_daily_prob`. Random attrition is off by default; when
+  enabled it fires at most one unscheduled departure per day, skipping leads.
+  _File: `config.yaml`_
+
+### Changed
+
+- **`DepartmentPlanner` prompt** — accepts a `lifecycle_context` string injected
+  between the cross-dept signals and known event types sections. When non-empty
+  it surfaces recent departures (with reassigned tickets), recent hires (with
+  warm edge count), and unresolved knowledge domains so the LLM plan reflects
+  actual roster state rather than a static org chart.
+  _File: `day_planner.py` — `DepartmentPlanner._PLAN_PROMPT`, `DepartmentPlanner.plan()`_
+
+- **`DayPlannerOrchestrator`** — holds a `validator` reference so
+  `patch_validator_for_lifecycle()` can update `_valid_actors` before each day's
+  plan is generated, without rebuilding the validator on every call.
+  _File: `day_planner.py` — `DayPlannerOrchestrator.__init__()`_
+
+- **`flow.py` module-level org state** — `ORG_CHART` and `PERSONAS` are now
+  copied into `LIVE_ORG_CHART` and `LIVE_PERSONAS` at startup. All roster-sensitive
+  code paths reference the live copies; the frozen originals remain available for
+  config introspection. `OrgLifecycleManager` mutates the live copies in place.
+  _File: `flow.py`_
+
+---
+
 ## [v0.2.0] — 2026-03-04
 
 ### Added
@@ -43,7 +159,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `ValidationResult` — outcome of a `PlanValidator` check
   - `KNOWN_EVENT_TYPES` — the vocabulary set the validator enforces; novel proposals
     outside this set are logged rather than silently dropped
-  _File: `planner_models.py` (new)_
+    _File: `planner_models.py` (new)_
 
 - **`plan_validator.py`** — integrity boundary between LLM proposals and the
   execution engine. Checks every `ProposedEvent` against five rules before the
@@ -57,7 +173,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
      `team_celebration` when `system_health < 40`)
   4. **Cooldown windows** — configurable per-event-type minimum days between firings
   5. **Morale gating** — `morale_intervention` only fires when morale is actually low
-  _File: `plan_validator.py` (new)_
+     _File: `plan_validator.py` (new)_
 
 - **`day_planner.py`** — LLM-driven planning layer that replaces `_generate_theme()`
   in `flow.py`. Three classes:
@@ -73,22 +189,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     Engineering's plan before `OrgCoordinator` looks for collision points.
     Rejected and novel events each produce their own SimEvent types so nothing
     is silently discarded.
-  _File: `day_planner.py` (new)_
+    _File: `day_planner.py` (new)_
 
 - **`normal_day.py` — `NormalDayHandler`** — replaces `_handle_normal_day()` in
   `flow.py` entirely. Dispatches each engineer's non-deferred agenda items to typed
   handlers that produce specific artifacts:
 
-  | `activity_type`    | Artifacts produced                                       |
-  |--------------------|----------------------------------------------------------|
-  | `ticket_progress`  | JIRA comment + optional blocker Slack thread             |
-  | `pr_review`        | GitHub bot message + optional author reply               |
-  | `1on1`             | DM thread (3–5 messages)                                 |
-  | `async_question`   | Slack thread (3–5 messages) in appropriate channel       |
-  | `design_discussion`| Slack thread + 30% chance Confluence design doc stub     |
-  | `mentoring`        | DM thread + double social graph edge boost               |
-  | `deep_work`        | SimEvent only — intentionally produces no artifact       |
-  | deferred (any)     | `agenda_item_deferred` SimEvent logging the interruption |
+  | `activity_type`     | Artifacts produced                                       |
+  | ------------------- | -------------------------------------------------------- |
+  | `ticket_progress`   | JIRA comment + optional blocker Slack thread             |
+  | `pr_review`         | GitHub bot message + optional author reply               |
+  | `1on1`              | DM thread (3–5 messages)                                 |
+  | `async_question`    | Slack thread (3–5 messages) in appropriate channel       |
+  | `design_discussion` | Slack thread + 30% chance Confluence design doc stub     |
+  | `mentoring`         | DM thread + double social graph edge boost               |
+  | `deep_work`         | SimEvent only — intentionally produces no artifact       |
+  | deferred (any)      | `agenda_item_deferred` SimEvent logging the interruption |
 
   Falls back to original random Slack chatter if `org_day_plan` is `None`,
   preserving compatibility with runs that predate the planning layer.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,19 @@
 
 **Synthetic corporate dataset generator for AI agent evaluation.**
 
-Echelon simulates weeks of realistic enterprise activity — Confluence pages, JIRA tickets, Slack threads, Git PRs, emails, and server logs — all grounded in an event-driven state machine so LLMs can't hallucinate facts out of sequence.
+OrgForge simulates weeks of realistic enterprise activity — Confluence pages, JIRA tickets, Slack threads, Git PRs, emails, and server logs — grounded in an event-driven state machine so LLMs can't hallucinate facts out of sequence.
+
+The org isn't static. Engineers leave mid-sprint. Tickets get orphaned. Knowledge gaps surface in real time. New hires start cold and warm up through simulated collaboration. Stress propagates through a live social graph. Every artifact reflects the actual state of the org at the moment it was written.
 
 ---
 
 ## Why Does This Exist?
 
-When building AI agents that reason over institutional knowledge, you need a realistic corpus to test against. The only widely-used corporate dataset is the Enron email corpus — and it's 25 years old, legally sensitive, and covers one company in crisis.
+When building AI agents that reason over institutional knowledge, you need a realistic corpus to test against. The only widely-used corporate dataset is the Enron email corpus — 25 years old, legally sensitive, and covering one company in crisis.
 
-OrgForge generates that corpus from scratch, parameterized to any company, industry, or org structure. Everything is grounded in a SimEvent log: LLMs write prose, but the facts — who was on-call, which ticket was open, when the incident resolved — are always controlled by the state machine.
+OrgForge generates that corpus from scratch, parameterized to any company, industry, or org structure. Everything is grounded in a SimEvent log: LLMs write prose, but the facts — who was on-call, which ticket was open, when the incident resolved, who just left the team — are always controlled by the state machine.
 
-The larger goal is proving that institutional knowledge capture is a solvable problem. OrgForge is the open-source testbed that builds toward that.
+The larger goal is proving that institutional knowledge capture is a solvable problem. OrgForge is the open-source testbed building toward that.
 
 ---
 
@@ -24,31 +26,31 @@ The larger goal is proving that institutional knowledge capture is a solvable pr
 
 A default 22-day simulation produces:
 
-| Artifact                   | Description                                                             |
-| -------------------------- | ----------------------------------------------------------------------- |
-| `confluence/archives/`     | Seed documents: technical specs, campaign briefs, OKR docs              |
-| `confluence/general/`      | Ad-hoc pages written during the simulation                              |
-| `confluence/postmortems/`  | Post-incident write-ups grounded in actual root causes                  |
-| `confluence/retros/`       | Sprint retrospectives referencing real velocity and incidents           |
-| `jira/`                    | Sprint tickets, P1 incident tickets with linked PRs                     |
-| `slack/channels/`          | Standup transcripts, incident alerts, engineering chatter, bot messages |
-| `git/prs/`                 | Pull requests with reviewers, merge status, linked tickets              |
-| `emails/threads/`          | Multi-turn incident escalation and knowledge gap threads                |
-| `emails/sprint/`           | Sprint kickoff and mid-point check-in emails                            |
-| `emails/leadership/`       | Weekly leadership sync summaries                                        |
-| `emails/hr/`               | Welcome email, morale intervention, remote policy                       |
-| `emails/sales/`            | Weekly pipeline updates referencing actual incident stability           |
-| `servers/logs/`            | AWS cost alerts, Snyk security findings, GitHub Actions output          |
-| `simulation_snapshot.json` | Full state: incidents, morale curve, system health, all artifact IDs    |
-| `simulation.log`           | Complete chronological system and debug logs for the entire run         |
+| Artifact                   | Description                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `confluence/archives/`     | Seed documents: technical specs, campaign briefs, OKR docs                                                                  |
+| `confluence/general/`      | Ad-hoc pages written during the simulation                                                                                  |
+| `confluence/postmortems/`  | Post-incident write-ups grounded in actual root causes                                                                      |
+| `confluence/retros/`       | Sprint retrospectives referencing real velocity and incidents                                                               |
+| `jira/`                    | Sprint tickets, P1 incident tickets with linked PRs                                                                         |
+| `slack/channels/`          | Standup transcripts, incident alerts, engineering chatter, bot messages                                                     |
+| `git/prs/`                 | Pull requests with reviewers, merge status, linked tickets                                                                  |
+| `emails/threads/`          | Multi-turn incident escalation and knowledge gap threads                                                                    |
+| `emails/sprint/`           | Sprint kickoff and mid-point check-in emails                                                                                |
+| `emails/leadership/`       | Weekly leadership sync summaries                                                                                            |
+| `emails/hr/`               | Welcome emails, morale interventions, remote policy                                                                         |
+| `emails/sales/`            | Weekly pipeline updates referencing actual incident stability                                                               |
+| `servers/logs/`            | AWS cost alerts, Snyk security findings, GitHub Actions output                                                              |
+| `simulation_snapshot.json` | Full state: incidents, morale curve, system health, relationship graph, departed employees, new hires, knowledge gap events |
+| `simulation.log`           | Complete chronological system and debug logs for the entire run                                                             |
 
-Every artifact references real SimEvent facts. The incident email thread cites the same root cause as the JIRA ticket. The postmortem links the correct PR. The sales email mentions platform instability on weeks that actually had incidents.
+Every artifact references real SimEvent facts. The incident email thread cites the same root cause as the JIRA ticket. The postmortem links the correct PR. The sales email mentions platform instability on weeks that actually had incidents. When an engineer departs, their tickets are reassigned and their knowledge gaps surface in subsequent incidents — not as static config, but as events the simulation discovers.
 
 ---
 
 ## Architecture & Mechanics
 
-OrgForge is not just an LLM wrapper. It uses a strict event-driven state machine (`CrewAI Flow`), a vector database (`MongoDB Atlas Local`), and a dynamic social graph (`NetworkX`) to prevent hallucinations and maintain temporal consistency.
+OrgForge is not an LLM wrapper. It uses a strict event-driven state machine (CrewAI Flow), a vector database (MongoDB Atlas Local), and a dynamic social graph (NetworkX) to prevent hallucinations and maintain temporal consistency.
 
 👉 **[Read the full Architecture Deep-Dive here.](ARCHITECTURE.md)**
 
@@ -64,8 +66,6 @@ OrgForge is not just an LLM wrapper. It uses a strict event-driven state machine
 | Local Ollama + Docker for the rest | `docker compose up mongodb orgforge` | Set `OLLAMA_BASE_URL` in `.env`             |
 | Cloud preset (AWS Bedrock)         | `docker compose up mongodb orgforge` | Set credentials in `.env`, skip Ollama      |
 | Fully local, no Docker             | `python flow.py`                     | Requires MongoDB and Ollama running locally |
-
-_(See the [`config/config.yaml`](config/config.yaml) file to customize the company, industry, and hardware presets)_
 
 ### Option 1 — Everything in Docker (Recommended)
 
@@ -87,26 +87,25 @@ Output lands in `./export/`.
 
 ### Option 2 — Local Ollama, Docker for MongoDB Only
 
-If you already have Ollama running on your machine, create a `.env` file:
+Create a `.env` file:
 
 ```bash
-# .env
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 ```
 
-Then start only the services you need:
+Then:
 
 ```bash
 docker compose up mongodb orgforge
 ```
 
-> **Linux note:** `host.docker.internal` requires Docker Desktop, or the `extra_hosts: host-gateway` entry in `docker-compose.yaml` (already included). Plain Docker Engine on Linux does not resolve this automatically without it.
+> **Linux note:** `host.docker.internal` requires Docker Desktop, or the `extra_hosts: host-gateway` entry in `docker-compose.yaml` (already included).
 
 ### Option 3 — Cloud Preset (AWS Bedrock + OpenAI)
 
 Best output quality. Uses Claude 3.5 Sonnet for document generation, Llama 3.1 8B on Bedrock for high-volume worker calls, and OpenAI `text-embedding-3-large` for embeddings.
 
-Set `quality_preset: "cloud"` in `config.yaml`, then create a `.env` file:
+Set `quality_preset: "cloud"` in `config.yaml`, then:
 
 ```bash
 # .env
@@ -116,56 +115,16 @@ AWS_DEFAULT_REGION=us-east-1
 OPENAI_API_KEY=...
 ```
 
-Install the cloud dependencies and start without Ollama:
-
 ```bash
 pip install boto3 langchain-aws openai
 docker compose up mongodb orgforge
 ```
 
-### Running on AWS EC2 or Cloud VMs
-
-If you want to run a massive dataset generation without tying up your laptop, you can easily deploy OrgForge to a cloud VM.
-
-#### Option A: The API Route (Cheap EC2 + Bedrock/OpenAI)
-
-You don't need a GPU for this. A cheap `t3.small` instance works perfectly because the cloud APIs do all the heavy lifting.
-
-1. Launch an EC2 instance (Ubuntu or Amazon Linux) and install Docker.
-2. Clone the repo: `git clone https://github.com/aeriesec/orgforge.git && cd orgforge`
-3. Copy the env file: `cp .env.example .env`
-4. Edit `.env`:
-   - Set `INSTALL_CLOUD_DEPS=true`
-   - Add your `OPENAI_API_KEY` and AWS Credentials.
-5. Edit `config/config.yaml` and set `quality_preset: "cloud"`
-6. Run it in the background:
-   ```bash
-   docker compose up --build -d mongodb orgforge
-   ```
-
-#### Option B: The Big Iron Route (GPU Instance + 70B Local Models)
-
-If you want to run `Llama 3.3 70B` entirely locally for maximum privacy, you'll need a GPU instance (e.g., an AWS `g5.2xlarge` or `g5.12xlarge`).
-
-1. Launch an instance using the **Deep Learning AMI** (which comes with NVIDIA drivers and Docker pre-installed).
-2. Open `docker-compose.yaml` and **uncomment the GPU `deploy` block** under the `ollama` service so the container can access the hardware.
-3. Edit `config/config.yaml` and set `quality_preset: "local_gpu"`.
-4. Start the stack:
-
-```bash
-docker compose up -d
-
-```
-
 ### Option 4 — Fully Local, No Docker
 
-Requires MongoDB Atlas Local and Ollama running on your machine:
-
 ```bash
-# Start MongoDB
 docker run -p 27017:27017 mongodb/mongodb-atlas-local
 
-# Pull models (local_cpu preset)
 ollama pull qwen2.5:7b-instruct-q4_K_M
 ollama pull qwen2.5:1.5b-instruct
 ollama pull mxbai-embed-large
@@ -174,6 +133,22 @@ pip install -r requirements.txt
 python src/flow.py
 python src/email_gen.py
 ```
+
+### Running on AWS EC2
+
+**Cheap EC2 + Bedrock/OpenAI (no GPU required)**
+
+A `t3.small` works fine — the cloud APIs do all the heavy lifting.
+
+1. Launch an EC2 instance (Ubuntu or Amazon Linux) and install Docker
+2. `git clone https://github.com/aeriesec/orgforge.git && cd orgforge`
+3. `cp .env.example .env` and fill in your credentials
+4. Set `quality_preset: "cloud"` in `config/config.yaml`
+5. `docker compose up --build -d mongodb orgforge`
+
+**GPU Instance + 70B Local Models**
+
+For `Llama 3.3 70B` entirely locally, use a `g5.2xlarge` or `g5.12xlarge` with the Deep Learning AMI. Uncomment the GPU `deploy` block under the `ollama` service in `docker-compose.yaml`, set `quality_preset: "local_gpu"`, then `docker compose up -d`.
 
 ---
 
@@ -184,8 +159,7 @@ python src/email_gen.py
 ### Quality Presets
 
 ```yaml
-# Switch between: "local_cpu" | "local_gpu" | "cloud"
-quality_preset: "local_cpu"
+quality_preset: "local_cpu" # local_cpu | local_gpu | cloud
 ```
 
 | Preset      | Planner                     | Worker                 | Embeddings             | Best For                        |
@@ -195,8 +169,6 @@ quality_preset: "local_cpu"
 | `cloud`     | Claude 3.5 Sonnet (Bedrock) | Llama 3.1 8B (Bedrock) | text-embedding-3-large | Production dataset generation   |
 
 ### Simulating a Different Company
-
-Change these sections in `config.yaml` — no Python required:
 
 ```yaml
 simulation:
@@ -208,38 +180,19 @@ legacy_system:
   name: "RiskEngine"
   project_name: "Project Mercury"
   description: "legacy risk calculation service"
-  aws_alert_message: "RiskEngine batch job costs remain elevated."
 
 incident_triggers:
   - "breach"
   - "compliance"
-  - "fail"
   - "timeout"
-  - "latency"
-
-sprint_ticket_themes:
-  - "Refactor {legacy_system} settlement logic"
-  - "Add circuit breaker to FX feed"
-  - "Fix race condition in order matching"
-  - "Basel III config audit"
-  - "Rate limiting on public API"
-
-knowledge_gaps:
-  - name: "Richard"
-    left: "2024-09"
-    role: "Head of Quant"
-    knew_about: ["RiskEngine", "legacy pricing model", "Basel III configs"]
-    documented_pct: 0.15
 
 org_chart:
-  Product: ["Dana", "Wei", "Priya"]
   Engineering: ["Sam", "Lena", "Omar", "Chris"]
   Risk: ["Felix", "Ingrid", "Tom"]
   Sales: ["Marcus", "Blake", "Tasha"]
   HR_Ops: ["Karen", "Dave"]
 
 leads:
-  Product: "Dana"
   Engineering: "Sam"
   Risk: "Felix"
   Sales: "Marcus"
@@ -248,26 +201,68 @@ leads:
 
 ### Key Config Sections
 
-| Section                   | What It Controls                                                            |
-| ------------------------- | --------------------------------------------------------------------------- |
-| `quality_preset`          | Which model profile is active                                               |
-| `simulation`              | Company name, domain, run duration, event probabilities                     |
-| `legacy_system`           | The unstable legacy system referenced in incidents, tickets, and docs       |
-| `incident_triggers`       | Keywords in the daily theme that trigger a P1 incident                      |
-| `sprint_ticket_themes`    | Pool of ticket titles drawn during sprint planning                          |
-| `adhoc_confluence_topics` | Spontaneous wiki pages generated on normal days                             |
-| `knowledge_gaps`          | Departed employees whose absence creates documentation gaps                 |
-| `roles`                   | Maps simulation roles (on-call, incident commander, HR lead) to departments |
-| `morale`                  | Decay rate, recovery rate, intervention threshold                           |
-| `org_chart` + `leads`     | Everyone in the company and who runs each department                        |
-| `personas`                | Writing style, stress level, and expertise per named employee               |
-| `external_contacts`       | External contacts                                                           |
+| Section                   | What It Controls                                                                |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `quality_preset`          | Which model profile is active                                                   |
+| `simulation`              | Company name, domain, run duration, event probabilities                         |
+| `legacy_system`           | The unstable system referenced in incidents, tickets, and docs                  |
+| `incident_triggers`       | Keywords in the daily theme that trigger a P1 incident                          |
+| `sprint_ticket_themes`    | Pool of ticket titles drawn during sprint planning                              |
+| `adhoc_confluence_topics` | Spontaneous wiki pages generated on normal days                                 |
+| `knowledge_gaps`          | Static departed employees whose absence creates documentation gaps from day one |
+| `org_lifecycle`           | Dynamic departures and hires that occur during the simulation (see below)       |
+| `roles`                   | Maps simulation roles (on-call, incident commander, HR lead) to departments     |
+| `morale`                  | Decay rate, recovery rate, intervention threshold                               |
+| `org_chart` + `leads`     | Everyone in the company and who runs each department                            |
+| `personas`                | Writing style, stress level, and expertise per named employee                   |
+| `external_contacts`       | Vendors, customers, and cloud providers that get pulled into incidents          |
+
+### Dynamic Org Lifecycle
+
+Engineers can join and leave during the simulation. Departures and hires are scheduled in config and execute before the day's planning runs, so every downstream artifact that day reflects the new roster.
+
+```yaml
+org_lifecycle:
+  scheduled_departures:
+    - name: "Jordan"
+      day: 12
+      reason: "voluntary" # voluntary | layoff | performance
+      role: "Senior Backend Engineer"
+      knowledge_domains:
+        - "auth-service"
+        - "redis-cache"
+      documented_pct: 0.25 # fraction written down — drives gap severity
+
+  scheduled_hires:
+    - name: "Taylor"
+      day: 15
+      dept: "Engineering"
+      role: "Backend Engineer"
+      expertise: ["Python", "FastAPI"]
+      style: "methodical, asks lots of questions before writing code"
+      tenure: "new"
+
+  enable_random_attrition: false
+  random_attrition_daily_prob: 0.005
+```
+
+**What happens on departure:**
+
+- Active incidents assigned to the departing engineer are handed off via Dijkstra escalation routing — while the node is still in the graph — to the next available person in the chain
+- Orphaned JIRA tickets are reassigned to the dept lead; `"In Progress"` tickets without a linked PR are reset to `"To Do"` so the new owner starts fresh; tickets with a PR keep their status so the review/merge flow closes them naturally
+- Betweenness centrality is recomputed on the smaller graph; nodes that absorb the departing engineer's bridging load receive a proportional stress hit (capped at 20 points)
+- An `employee_departed` SimEvent is emitted with edge snapshot, centrality at departure, reassigned tickets, and incident handoffs — full ground truth for retrieval evaluation
+
+**What happens on hire:**
+
+- New engineer enters the graph with cold-start edges at `edge_weight_floor` to cross-dept nodes and `2× floor` to same-dept peers — both below the `warmup_threshold` so the day planner naturally proposes `warmup_1on1` and `onboarding_session` events until real collaboration warms the edges
+- An `employee_hired` SimEvent is emitted; the hire appears in `simulation_snapshot.json` with their final warm-edge count
 
 ---
 
 ## How the Event Bus Works
 
-Every significant action in the simulation emits a `SimEvent`:
+Every significant action emits a `SimEvent`:
 
 ```python
 SimEvent(
@@ -279,16 +274,31 @@ SimEvent(
     facts={
         "title": "TitanDB: latency spike",
         "root_cause": "connection pool exhaustion under load",
-        "involves_bill": True
+        "involves_gap": True
     },
     summary="P1 incident IT-108: connection pool exhaustion",
     tags=["incident", "P1"]
 )
 ```
 
-Every downstream artifact — the email thread, the postmortem, the Slack alert — pulls its facts from the event log rather than asking an LLM to invent them. This is what prevents temporal drift and hallucination across a multi-week simulation.
+Every downstream artifact pulls its facts from the event log rather than asking an LLM to invent them. This prevents temporal drift and hallucination across a multi-week simulation.
 
-The SimEvent log is also what makes the dataset useful for RAG evaluation: you have ground truth about what happened, when, and who was involved, so you can measure whether a retrieval system actually surfaces the right context.
+The end-of-day `day_summary` SimEvent captures a structured snapshot of everything that happened:
+
+```python
+facts={
+    "active_actors":        ["Jax", "Sarah", "Morgan"],
+    "dominant_event":       "incident_opened",
+    "event_type_counts":    {"incident_opened": 1, "pr_review": 2, "standup": 1},
+    "departments_involved": ["Engineering"],
+    "open_incidents":       ["IT-108"],
+    "stress_snapshot":      {"Jax": 72, "Sarah": 55, "Morgan": 41},
+    "health_trend":         "degraded",
+    "morale_trend":         "moderate",
+}
+```
+
+This is what makes the dataset useful for RAG evaluation: you have ground truth about what happened, when, who was involved, and what the org's state was — so you can measure whether a retrieval system actually surfaces the right context.
 
 ---
 
@@ -300,19 +310,7 @@ The SimEvent log is also what makes the dataset useful for RAG evaluation: you h
 | `local_gpu` | ~48 GB VRAM  | Llama 3.3 70B — requires A100 or 2× A10G |
 | `cloud`     | ~500 MB      | Only MongoDB + Python run locally        |
 
-For `local_gpu` on AWS, a `g5.2xlarge` (A10G 24GB) runs the 70B model at q4 quantization. At ~$0.50/hour spot pricing a full 22-day simulation costs roughly $3–5.
-
----
-
-## Adding a New Artifact Type
-
-The codebase is structured for extension. To add a new artifact type (Zoom transcripts, Zendesk tickets, PagerDuty alerts):
-
-1. Add an event emission in `flow.py` when the triggering condition occurs
-2. Write a handler method that reads from the SimEvent log and generates the artifact
-3. Call it from `email_gen.py`'s `run()` method, or as a new post-processing script
-
-A formal plugin architecture is on the roadmap. If you want to add a new artifact type, open an issue first so we can align on the interface.
+For `local_gpu` on AWS, a `g5.2xlarge` (A10G 24GB) runs 70B at q4 quantization. At ~$0.50/hour spot pricing a full 22-day simulation costs roughly $3–5.
 
 ---
 
@@ -320,19 +318,24 @@ A formal plugin architecture is on the roadmap. If you want to add a new artifac
 
 ```
 orgforge/
-├── .github/workflows/   # CI/CD pipelines
-├── src/                 # Application source code
-│   ├── flow.py          # State machine and simulation engine
-│   ├── email_gen.py     # Reflective post-processing artifacts
-│   ├── memory.py        # Vector DB and Event Bus
-│   └── graph_dynamics.py# Social graph and network logic
-├── config/              # YAML Configurations
-├── tests/               # Pytest suite
-├── scripts/             # Entrypoint and helper scripts
-├── export/              # Output directory for generated dataset
+├── .github/workflows/    # CI/CD pipelines
+├── src/
+│   ├── flow.py           # State machine and simulation engine
+│   ├── day_planner.py    # LLM-driven per-department daily planning
+│   ├── normal_day.py     # Agenda dispatcher — produces typed artifacts per activity
+│   ├── planner_models.py # Dataclasses for plans, events, and validation results
+│   ├── plan_validator.py # Integrity boundary between LLM proposals and execution
+│   ├── org_lifecycle.py  # Dynamic hiring, firing, and knowledge gap propagation
+│   ├── graph_dynamics.py # Social graph: stress propagation, edge decay, escalation
+│   ├── memory.py         # Vector DB and SimEvent bus
+│   └── email_gen.py      # Reflective post-processing artifacts
+├── config/               # YAML configurations
+├── tests/                # Pytest suite
+├── scripts/              # Entrypoint and helper scripts
+├── export/               # Output directory for generated dataset
 ├── README.md
-├── ARCHITECTURE.md      # Deep dive into the engine
-└── CONTRIBUTING.md      # Guidelines for opening PRs
+├── ARCHITECTURE.md
+└── CONTRIBUTING.md
 ```
 
 ---
@@ -347,12 +350,22 @@ orgforge/
 
 ---
 
+## Adding a New Artifact Type
+
+1. Add an event emission in `flow.py` when the triggering condition occurs
+2. Write a handler that reads from the SimEvent log and generates the artifact
+3. Call it from `email_gen.py`'s `run()` method or as a new post-processing script
+
+A formal plugin architecture is on the roadmap. Open an issue before starting so we can align on the interface.
+
+---
+
 ## Contributing
 
-Contributions are welcome! Please read our **[Contributing Guidelines](CONTRIBUTING.md)** before opening a Pull Request. If you are adding a new domain config or artifact type, please open an Issue first to discuss it.
+Contributions are welcome. Please read **[CONTRIBUTING.md](CONTRIBUTING.md)** before opening a PR. For new domain configs or artifact types, open an Issue first.
 
 ---
 
 ## License
 
-This project is licensed under the MIT License - see the **[LICENSE](LICENSE)** file for details.
+MIT — see **[LICENSE](LICENSE)**.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -192,6 +192,62 @@ leads:
   HR_Ops: "Karen"
   QA_Support: "Nadia"
 
+org_lifecycle:
+  # ── Scheduled departures ──────────────────────────────────────────────────
+  # Each entry fires exactly once on the specified day, before planning runs.
+  scheduled_departures:
+    - name: "Jordan"
+      day: 12
+      reason: "voluntary" # voluntary | layoff | performance
+      role: "Senior Backend Engineer"
+      knowledge_domains:
+        - "auth-service"
+        - "redis-cache"
+        - "oauth2-flow"
+      documented_pct: 0.25 # only 25% written down — high gap risk
+
+    - name: "Morgan"
+      day: 30
+      reason: "layoff"
+      role: "DevOps Engineer"
+      knowledge_domains:
+        - "kubernetes-deploy"
+        - "terraform-infra"
+      documented_pct: 0.60
+
+  # ── Scheduled hires ───────────────────────────────────────────────────────
+  # New engineers enter the graph at edge_weight_floor on the specified day.
+  # The DepartmentPlanner will propose warmup_1on1 and onboarding_session
+  # events naturally once the roster context shows them as "still warming up".
+  scheduled_hires:
+    - name: "Taylor"
+      day: 15 # arrives 3 days after Jordan leaves
+      dept: "Engineering"
+      role: "Backend Engineer"
+      expertise:
+        - "Python"
+        - "FastAPI"
+        - "PostgreSQL"
+      style: "methodical, asks lots of questions before writing code"
+      tenure: "new"
+
+    - name: "Reese"
+      day: 35
+      dept: "Engineering"
+      role: "DevOps Engineer"
+      expertise:
+        - "Kubernetes"
+        - "Terraform"
+        - "AWS"
+      style: "direct, prefers async communication, strong documentation habit"
+      tenure: "new"
+
+  # ── Random attrition (optional, off by default) ───────────────────────────
+  # When enabled, every non-lead employee has a daily probability of leaving.
+  # Useful for longer simulations (60+ days) to stress-test RAG evaluation.
+  enable_random_attrition: false
+  random_attrition_daily_prob: 0.005 # 0.5% per employee per day ≈ ~1 departure/month
+
 # ── PERSONAS ──────────────────────────────────────────────────
 personas:
   Jax:

--- a/src/day_planner.py
+++ b/src/day_planner.py
@@ -80,6 +80,8 @@ class DepartmentPlanner:
     CROSS-DEPARTMENT SIGNALS (what other teams are dealing with):
     {cross_signals}
 
+    {lifecycle_context}
+
     KNOWN EVENT TYPES YOU CAN PROPOSE:
     {known_types}
 
@@ -154,6 +156,7 @@ class DepartmentPlanner:
         graph_dynamics:  GraphDynamics,
         cross_signals:   List[CrossDeptSignal],
         eng_plan:        Optional[DepartmentDayPlan] = None,  # None for Engineering itself
+        lifecycle_context: str = "",
     ) -> DepartmentDayPlan:
         """
         Produce a DepartmentDayPlan. eng_plan is provided to non-Engineering
@@ -167,6 +170,10 @@ class DepartmentPlanner:
         morale_label  = (
             "low" if state.team_morale < 0.45 else
             "moderate" if state.team_morale < 0.70 else "healthy"
+        )
+        lifecycle_context=(
+            f"\nROSTER CHANGES (recent hires/departures):\n{lifecycle_context}\n"
+            if lifecycle_context else ""
         )
 
         prompt = self._PLAN_PROMPT.format(
@@ -182,6 +189,7 @@ class DepartmentPlanner:
             dept_history=dept_history,
             cross_signals=cross_str,
             known_types=known_str,
+            lifecycle_context=lifecycle_context,
         )
 
         agent = Agent(
@@ -628,6 +636,7 @@ class DayPlannerOrchestrator:
         state,
         mem:            Memory,
         graph_dynamics: GraphDynamics,
+        lifecycle_context: str = "",
     ) -> OrgDayPlan:
         """
         Full planning pass for one day.
@@ -675,6 +684,7 @@ class DayPlannerOrchestrator:
                 graph_dynamics=graph_dynamics,
                 cross_signals=cross_signals_by_dept.get(dept, []),
                 eng_plan=eng_plan,
+                lifecycle_context=lifecycle_context,
             )
             self._patch_stress_levels(plan, graph_dynamics)
             dept_plans[dept] = plan

--- a/src/flow.py
+++ b/src/flow.py
@@ -34,6 +34,11 @@ from langchain_ollama import OllamaLLM
 
 from memory import Memory, SimEvent
 from graph_dynamics import GraphDynamics
+from org_lifecycle import (
+         OrgLifecycleManager,
+         patch_validator_for_lifecycle,
+         recompute_escalation_after_departure,
+     )
 
 os.makedirs("./export", exist_ok=True)
 
@@ -86,6 +91,8 @@ DEPARTED_EMPLOYEES: Dict[str, Dict] = {
 }
 
 ALL_NAMES = [name for dept in ORG_CHART.values() for name in dept]
+LIVE_ORG_CHART  = {dept: list(members) for dept, members in ORG_CHART.items()}
+LIVE_PERSONAS   = {k: dict(v) for k, v in PERSONAS.items()}
 
 # ── Active preset ─────────────────────────────
 _PRESET_NAME = CONFIG.get("quality_preset", "local_cpu")
@@ -268,6 +275,9 @@ class State(BaseModel):
     org_day_plan: Optional[Any] = None
     daily_active_actors: List[str] = []
     daily_event_type_counts: Dict[str, int] = {}
+    departed_employees: Dict[str, Dict] = {}   # name → {left, role, knew_about, documented_pct}
+    new_hires: Dict[str, Dict] = {}   # name → {joined, role, dept, expertise}
+
 
 # ─────────────────────────────────────────────
 # 3. FILE I/O
@@ -422,6 +432,16 @@ class Flow(Flow[State]):
             graph_dynamics=self.graph_dynamics, social_graph=self.social_graph,
             git=self._git, worker_llm=WORKER_MODEL, planner_llm=PLANNER_MODEL,
         )
+        self._lifecycle = OrgLifecycleManager(
+            config=CONFIG,
+            graph_dynamics=self.graph_dynamics,
+            mem=self._mem,
+            org_chart=LIVE_ORG_CHART,
+            personas=LIVE_PERSONAS,
+            all_names=ALL_NAMES,
+            leads=LEADS,
+            worker_llm=WORKER_MODEL,
+        )
 
         stats = self._mem.stats()
         logger.info(f"[dim]Memory: provider={stats['embed_provider']} model={stats['embed_model']} dims={stats['embed_dims']} MongoDB={'✓' if stats['mongodb_ok'] else '⚠'}[/dim]")
@@ -554,6 +574,18 @@ class Flow(Flow[State]):
                 self.state.current_date += timedelta(days=1)
                 continue
 
+            date_str = str(self.state.current_date.date())
+            departures = self._lifecycle.process_departures(self.state.day, date_str, self.state)
+            hires      = self._lifecycle.process_hires(self.state.day, date_str, self.state)
+
+            if departures or hires:
+                # Patch the day planner's validator to reflect the new roster
+                patch_validator_for_lifecycle(self._day_planner.validator, self._lifecycle)
+
+            org_plan = self._day_planner.plan(
+                self.state, self._mem, self.graph_dynamics,
+                lifecycle_context=self._lifecycle.get_roster_context(),
+            )
             org_plan = self._day_planner.plan(self.state, self._mem, self.graph_dynamics)
             self.state.daily_theme  = org_plan.org_theme
             self.state.org_day_plan = org_plan
@@ -694,16 +726,24 @@ class Flow(Flow[State]):
         incident_lead = resolve_role("incident_commander")
         eng_peer      = next((n for n in ORG_CHART.get(CONFIG["roles"].get("on_call_engineer", ""), []) if n != on_call), on_call)
 
-        # Check if any departed employee's known systems appear in today's theme
-        involves_gap = any(
-            k.lower() in self.state.daily_theme.lower()
-            for emp in DEPARTED_EMPLOYEES.values()
-            for k in emp["knew_about"]
-        )
 
         rc_agent = Agent(role="Senior Engineer", goal="Diagnose root cause.", backstory=persona_backstory(on_call, self._mem, graph_dynamics=self.graph_dynamics), llm=WORKER_MODEL)
         rc_task  = Task(description=f"Theme: {self.state.daily_theme}\nWrite ONE specific technical root cause (max 20 words).", expected_output="One sentence.", agent=rc_agent)
         root_cause = str(Crew(agents=[rc_agent], tasks=[rc_task], verbose=False, llm=PLANNER_MODEL).kickoff()).strip()
+
+        involves_gap = any(
+            k.lower() in root_cause.lower()
+            for emp in DEPARTED_EMPLOYEES.values()
+            for k in emp["knew_about"]
+        )
+
+        self._lifecycle.scan_for_knowledge_gaps(
+            text=root_cause,
+            triggered_by=ticket_id,
+            day=self.state.day,
+            date_str=str(self.state.current_date.date()),
+            state=self.state,
+        )
 
         title  = f"{LEGACY['name']}: {self.state.daily_theme[:60]}"
         ticket = {"id": ticket_id, "title": title, "status": "In Progress", "assignee": on_call, "root_cause": root_cause, "linked_prs": []}
@@ -918,6 +958,15 @@ class Flow(Flow[State]):
         content = str(Crew(agents=[writer], tasks=[task], verbose=False, llm=PLANNER_MODEL).kickoff())
 
         full_content = f"# {title}\n**ID:** {conf_id}  \n**Author:** {author}\n\n" + content + bill_gap_warning(title)
+
+        self._lifecycle.scan_for_knowledge_gaps(
+            text=full_content,
+            triggered_by=conf_id,
+            day=self.state.day,
+            date_str=str(self.state.current_date.date()),
+            state=self.state,
+        )
+        
         path = f"{BASE}/confluence/general/{conf_id}.md"
         save_md(path, full_content)
         entry = {"id": conf_id, "title": title, "path": path}
@@ -1029,6 +1078,36 @@ class Flow(Flow[State]):
         self.state.daily_active_actors      = []   # new
         self.state.daily_event_type_counts  = {}   # new
 
+        date_str = str(self.state.current_date.date())
+        for dep in self._lifecycle._departed:
+            if dep.day != self.state.day:
+                continue   # only process today's departures
+            # Pick the on-call engineer or first dept member as first responder
+            dept_members = [
+                n for n in LIVE_ORG_CHART.get(dep.dept, [])
+                if n != dep.name
+            ]
+            if dept_members:
+                note = recompute_escalation_after_departure(
+                    self.graph_dynamics,
+                    departed=dep,
+                    first_responder=dept_members[0],
+                )
+                self._mem.log_event(SimEvent(
+                    type="escalation_chain",
+                    day=self.state.day,
+                    date=date_str,
+                    actors=dept_members[:2],
+                    artifact_ids={},
+                    facts={
+                        "trigger":       "post_departure_reroute",
+                        "departed":      dep.name,
+                        "new_path_note": note,
+                    },
+                    summary=f"Escalation path updated after {dep.name} departure. {note}",
+                    tags=["escalation_chain", "lifecycle"],
+                ))
+
         self.graph_dynamics.decay_edges()
         self._last_stress_prop = self.graph_dynamics.propagate_stress()
         prop = self._last_stress_prop
@@ -1057,6 +1136,9 @@ class Flow(Flow[State]):
             ("Git PRs", str(len(self.state.pr_registry))),
             ("Incidents Resolved", str(len(self.state.resolved_incidents))),
             ("Embedded Artifacts", str(s["artifact_count"])),
+            ("Employees Departed", str(len(self._lifecycle._departed))),
+            ("Employees Hired",    str(len(self._lifecycle._hired))),
+            ("Knowledge Gaps Surfaced", str(len(self._lifecycle._gap_events))),
             ("MongoDB Active", "✓" if s["mongodb_ok"] else "⚠"),
         ]:
             table.add_row(*row)
@@ -1071,6 +1153,43 @@ class Flow(Flow[State]):
         }
         snapshot["top_relationships"] = self.graph_dynamics.relationship_summary(10)
         snapshot["estranged_pairs"] = self.graph_dynamics.estranged_pairs()
+        snapshot["departed_employees"] = [
+            {
+                "name":              d.name,
+                "dept":              d.dept,
+                "day":               d.day,
+                "reason":            d.reason,
+                "knowledge_domains": d.knowledge_domains,
+                "documented_pct":    d.documented_pct,
+                "peak_stress":       d.peak_stress,
+            }
+            for d in self._lifecycle._departed
+        ]
+        snapshot["new_hires"] = [
+            {
+                "name":      h.name,
+                "dept":      h.dept,
+                "day":       h.day,
+                "role":      h.role,
+                "expertise": h.expertise,
+                "warm_edges_at_end": sum(
+                    1 for nb in self.social_graph.neighbors(h.name)
+                    if self.social_graph.has_node(h.name)
+                    and self.social_graph[h.name][nb].get("weight", 0) >= h.warmup_threshold
+                ) if self.social_graph.has_node(h.name) else 0,
+            }
+            for h in self._lifecycle._hired
+        ]
+        snapshot["knowledge_gap_events"] = [
+            {
+                "departed":       g.departed_name,
+                "domain":         g.domain_hit,
+                "triggered_by":   g.triggered_by,
+                "day":            g.triggered_on_day,
+                "documented_pct": g.documented_pct,
+            }
+            for g in self._lifecycle._gap_events
+        ]
         snapshot["stress_snapshot"] = self._last_stress_prop.stress_snapshot if hasattr(self, '_last_stress_prop') else {}
         save_json(f"{BASE}/simulation_snapshot.json", snapshot)
 

--- a/src/graph_dynamics.py
+++ b/src/graph_dynamics.py
@@ -77,6 +77,7 @@ class GraphDynamics:
 
         self._org_chart: Dict[str, List[str]] = config.get("org_chart", {})
         self._leads: Dict[str, str] = config.get("leads", {})
+        self._departed_names: set = set()
 
     # ── 1. STRESS / BURNOUT PROPAGATION ──────────────────────────────────────
 
@@ -170,6 +171,20 @@ class GraphDynamics:
     def record_incident_collaboration(self, actors: List[str]) -> None:
         """Boost edges among incident co-responders. Call in _handle_incident()."""
         self._boost_pairs(actors, self.cfg["incident_boost"])
+
+    def warm_up_edge(self, new_hire: str, colleague: str, boost: float) -> None:
+        """
+        Deliberately warm a new hire's edge to a specific colleague.
+        Called by org_lifecycle when an onboarding_session or warmup_1on1 fires.
+        The boost is added on top of the current weight, respecting the floor.
+        """
+        if not self.G.has_edge(new_hire, colleague):
+            floor = self.cfg.get("edge_weight_floor", 0.5)
+            self.G.add_edge(new_hire, colleague, weight=floor)
+        self.G[new_hire][colleague]["weight"] = round(
+            self.G[new_hire][colleague].get("weight", 0.5) + boost, 4
+        )
+        self._centrality_dirty = True
 
     def decay_edges(self) -> None:
         """

--- a/src/org_lifecycle.py
+++ b/src/org_lifecycle.py
@@ -1,0 +1,809 @@
+"""
+org_lifecycle.py
+================
+Dynamic hiring and firing for OrgForge.
+
+Principle: The Python engine controls all mutations to org state, the social
+graph, and the SimEvent log. LLMs only produce the *narrative prose* (Slack
+announcements, onboarding docs, farewell messages). They never touch State.
+
+Three public entry points called from flow.py:
+  OrgLifecycleManager.process_departures(day, state, ...)
+  OrgLifecycleManager.process_hires(day, state, ...)
+  OrgLifecycleManager.get_roster_context()   ← for DepartmentPlanner prompts
+
+Three departure side-effects handled deterministically (no LLM involvement):
+  1. JIRA ticket reassignment — orphaned tickets are reassigned to the dept
+     lead and transitioned back to "To Do" so they stay in the sprint backlog.
+  2. Centrality vacuum — after node removal the betweenness cache is dirtied
+     and an immediate recomputation is triggered; the resulting centrality
+     shift is used to apply a one-time "vacuum stress" to the neighbours who
+     absorbed the departing node's bridging load.
+  3. Active incident handoff — if the departing engineer is the named
+     responder on any live incident, ownership is forcibly transferred to the
+     next person in the Dijkstra escalation chain before the node is removed.
+
+Config schema (add to config.yaml under "org_lifecycle"):
+  org_lifecycle:
+    scheduled_departures:
+      - name: "Jordan"
+        day: 15
+        reason: "voluntary"          # voluntary | layoff | performance
+        role: "Senior Backend Engineer"
+        knowledge_domains: ["auth-service", "redis-cache"]
+        documented_pct: 0.30
+    scheduled_hires:
+      - name: "Taylor"
+        day: 18
+        dept: "Engineering"
+        role: "Backend Engineer"
+        expertise: ["Python", "Kafka"]
+        style: "methodical, asks lots of questions"
+        tenure: "new"
+    enable_random_attrition: false
+    random_attrition_daily_prob: 0.01
+    # Stress points applied per unit of centrality gained after a departure
+    centrality_vacuum_stress_multiplier: 40
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+import networkx as nx
+
+from memory import Memory, SimEvent
+from graph_dynamics import GraphDynamics
+
+logger = logging.getLogger("orgforge.lifecycle")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DATA TYPES
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class DepartureRecord:
+    """Immutable record of an engineer who has left the organisation."""
+    name:                    str
+    dept:                    str
+    role:                    str
+    day:                     int
+    reason:                  str           # voluntary | layoff | performance
+    knowledge_domains:       List[str]
+    documented_pct:          float
+    peak_stress:             int
+    edge_snapshot:           Dict[str, float]   # {neighbour: weight} before removal
+    centrality_at_departure: float = 0.0
+    # Populated by the departure engine's side-effect methods
+    reassigned_tickets:  List[str] = field(default_factory=list)
+    incident_handoffs:   List[str] = field(default_factory=list)
+
+
+@dataclass
+class HireRecord:
+    """An engineer who has joined. Enters the graph at edge_weight_floor."""
+    name:             str
+    dept:             str
+    day:              int
+    role:             str
+    expertise:        List[str]
+    style:            str
+    tenure:           str   = "new"
+    warmup_threshold: float = 2.0   # edges below this = "not yet collaborating"
+
+
+@dataclass
+class KnowledgeGapEvent:
+    departed_name:    str
+    domain_hit:       str
+    triggered_by:     str
+    triggered_on_day: int
+    documented_pct:   float
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MANAGER
+# ─────────────────────────────────────────────────────────────────────────────
+
+class OrgLifecycleManager:
+    """
+    Owns all mutations to org_chart, personas, GraphDynamics, and the
+    State departure/hire ledgers.  N
+
+    LLM usage is limited to a single call: _generate_backfill_name(), which
+    asks the worker LLM for a unique name for an unplanned hire. All other
+    mutations — graph changes, JIRA reassignment, incident handoff, stress
+    propagation — are deterministic. The engine never delegates facts to the LLM.
+    """
+
+    def __init__(
+        self,
+        config:         dict,
+        graph_dynamics: GraphDynamics,
+        mem:            Memory,
+        org_chart:      Dict[str, List[str]],   # mutable — mutated in place
+        personas:       Dict[str, dict],         # mutable — mutated in place
+        all_names:      List[str],               # mutable — mutated in place
+        leads:          Dict[str, str],
+        worker_llm=None,
+    ):
+        self._cfg       = config.get("org_lifecycle", {})
+        self._gd        = graph_dynamics
+        self._mem       = mem
+        self._org_chart = org_chart
+        self._personas  = personas
+        self._all_names = all_names
+        self._leads     = leads
+        self._llm       = worker_llm
+
+        self._departed:   List[DepartureRecord]   = []
+        self._hired:      List[HireRecord]        = []
+        self._gap_events: List[KnowledgeGapEvent] = []
+        self._domains_surfaced: Set[str]          = set()
+
+        # Build day-keyed lookup tables from config
+        self._scheduled_departures: Dict[int, List[dict]] = {}
+        for dep in self._cfg.get("scheduled_departures", []):
+            self._scheduled_departures.setdefault(dep["day"], []).append(dep)
+
+        self._scheduled_hires: Dict[int, List[dict]] = {}
+        for hire in self._cfg.get("scheduled_hires", []):
+            self._scheduled_hires.setdefault(hire["day"], []).append(hire)
+
+    # ─── PUBLIC ───────────────────────────────────────────────────────────────
+
+    def process_departures(
+        self, day: int, date_str: str, state
+    ) -> List[DepartureRecord]:
+        departures: List[DepartureRecord] = []
+
+        for dep_cfg in self._scheduled_departures.get(day, []):
+            record = self._execute_departure(dep_cfg, day, date_str, state, scheduled=True)
+            if record:
+                departures.append(record)
+
+        if self._cfg.get("enable_random_attrition", False):
+            prob = self._cfg.get("random_attrition_daily_prob", 0.01)
+            candidates = [
+                n for n in list(self._all_names)
+                if n not in self._leads.values()
+                and n not in [d.name for d in self._departed]
+            ]
+            for candidate in candidates:
+                if random.random() < prob:
+                    dept = next(
+                        (d for d, m in self._org_chart.items() if candidate in m),
+                        "Unknown"
+                    )
+                    dept_members = [
+                        n for n in self._org_chart.get(dept, [])
+                        if n not in self._leads.values()
+                    ]
+                    min_size = self._cfg.get("min_dept_size", 2)
+                    if len(dept_members) <= min_size:
+                        continue
+
+                    attrition_cfg = {
+                        "name":              candidate,
+                        "reason":            "voluntary",
+                        "knowledge_domains": [],
+                        "documented_pct":    0.5,
+                        # role intentionally omitted — _execute_departure resolves it
+                        # from personas so we don't hardcode anything here
+                    }
+                    record = self._execute_departure(
+                        attrition_cfg, day, date_str, state, scheduled=False
+                    )
+                    if record:
+                        departures.append(record)
+                    break
+
+        return departures
+
+    def process_hires(
+        self, day: int, date_str: str, state
+    ) -> List[HireRecord]:
+        hires: List[HireRecord] = []
+        for hire_cfg in self._scheduled_hires.get(day, []):
+            record = self._execute_hire(hire_cfg, day, date_str, state)
+            if record:
+                hires.append(record)
+        return hires
+
+    def scan_for_knowledge_gaps(
+        self, text: str, triggered_by: str, day: int, date_str: str, state
+    ) -> List[KnowledgeGapEvent]:
+        found: List[KnowledgeGapEvent] = []
+        text_lower = text.lower()
+        for record in self._departed:
+            for domain in record.knowledge_domains:
+                if domain.lower() not in text_lower:
+                    continue
+                gap_key = f"{record.name}:{domain}"
+                if gap_key in self._domains_surfaced:
+                    continue
+                self._domains_surfaced.add(gap_key)
+                gap_event = KnowledgeGapEvent(
+                    departed_name=record.name, domain_hit=domain,
+                    triggered_by=triggered_by, triggered_on_day=day,
+                    documented_pct=record.documented_pct,
+                )
+                self._gap_events.append(gap_event)
+                found.append(gap_event)
+                self._mem.log_event(SimEvent(
+                    type="knowledge_gap_detected", day=day, date=date_str,
+                    actors=[record.name], artifact_ids={"trigger": triggered_by},
+                    facts={
+                        "departed_employee":    record.name,
+                        "domain":               domain,
+                        "triggered_by":         triggered_by,
+                        "documented_pct":       record.documented_pct,
+                        "days_since_departure": day - record.day,
+                        "escalation_harder":    True,
+                    },
+                    summary=(
+                        f"Knowledge gap: {domain} (owned by ex-{record.name}) "
+                        f"surfaced in {triggered_by}. "
+                        f"~{int(record.documented_pct * 100)}% documented."
+                    ),
+                    tags=["knowledge_gap", "departed_employee"],
+                ))
+                logger.info(
+                    f"    [yellow]⚠ Knowledge gap:[/yellow] {domain} "
+                    f"(was {record.name}'s) surfaced in {triggered_by}"
+                )
+        return found
+
+    def get_roster_context(self) -> str:
+        lines: List[str] = []
+        for d in self._departed[-3:]:
+            gap_str    = (f"Knowledge gaps: {', '.join(d.knowledge_domains)}. "
+                          f"~{int(d.documented_pct*100)}% documented."
+                          if d.knowledge_domains else "No critical knowledge gaps.")
+            ticket_str = (f" Reassigned: {', '.join(d.reassigned_tickets)}."
+                          if d.reassigned_tickets else "")
+            handoff_str = (f" Incident handoffs: {', '.join(d.incident_handoffs)}."
+                           if d.incident_handoffs else "")
+            if not lines:
+                lines.append("RECENT DEPARTURES:")
+            lines.append(
+                f"  - {d.name} ({d.dept}) left Day {d.day} [{d.reason}]. "
+                f"{gap_str}{ticket_str}{handoff_str}"
+            )
+        for h in self._hired[-3:]:
+            warm = self._count_warm_edges(h)
+            if not any("RECENT HIRES" in l for l in lines):
+                lines.append("RECENT HIRES (still warming up):")
+            lines.append(
+                f"  - {h.name} ({h.dept}, {h.role}) joined Day {h.day}. "
+                f"Warm collaborations so far: {warm}. Needs mentoring/1on1s."
+            )
+        return "\n".join(lines) if lines else ""
+
+    def warm_up_edge(self, new_hire: str, colleague: str, boost: float) -> None:
+        """Call from flow.py when onboarding_session or warmup_1on1 fires."""
+        G     = self._gd.G
+        floor = self._gd.cfg.get("edge_weight_floor", 0.5)
+        if not G.has_edge(new_hire, colleague):
+            G.add_edge(new_hire, colleague, weight=floor)
+        G[new_hire][colleague]["weight"] = round(
+            G[new_hire][colleague].get("weight", floor) + boost, 4
+        )
+        self._gd._centrality_dirty = True
+
+    def departed_names(self)   -> List[str]: return [d.name for d in self._departed]
+    def new_hire_names(self)   -> List[str]: return [h.name for h in self._hired]
+    def find_departure(self, name: str) -> Optional[DepartureRecord]:
+        return next((d for d in self._departed if d.name == name), None)
+    def find_hire(self, name: str) -> Optional[HireRecord]:
+        return next((h for h in self._hired if h.name == name), None)
+
+    # ─── DEPARTURE ENGINE ─────────────────────────────────────────────────────
+
+    def _execute_departure(
+        self, dep_cfg: dict, day: int, date_str: str, state, scheduled: bool
+    ) -> Optional[DepartureRecord]:
+        name = dep_cfg["name"]
+        G    = self._gd.G
+
+        if name not in G:
+            logger.warning(f"[lifecycle] '{name}' not in graph — skipping departure.")
+            return None
+
+        dept      = next((d for d, m in self._org_chart.items() if name in m), "Unknown")
+        dept_lead = self._leads.get(dept) or next(iter(self._leads.values()))
+
+        actual_role = (
+            dep_cfg.get("role")
+            or self._personas.get(name, {}).get("role")
+            or f"{dept} Employee"
+        )
+
+        # Snapshot before any mutation
+        edge_snapshot        = {nb: G[name][nb].get("weight", 1.0) for nb in G.neighbors(name)}
+        peak_stress          = self._gd._stress.get(name, 30)
+        centrality_before    = dict(self._gd._get_centrality())
+        departing_centrality = centrality_before.get(name, 0.0)
+
+        record = DepartureRecord(
+            name=name, dept=dept, role=actual_role, day=day,
+            reason=dep_cfg.get("reason", "voluntary"),
+            knowledge_domains=dep_cfg.get("knowledge_domains", []),
+            documented_pct=float(dep_cfg.get("documented_pct", 0.5)),
+            peak_stress=peak_stress,
+            edge_snapshot=edge_snapshot,
+            centrality_at_departure=departing_centrality,
+        )
+
+        # Side-effects run in this exact order so each can still reference live graph:
+        #   1. Incident handoff   — needs Dijkstra path through departing node
+        #   2. JIRA reassignment  — reads ticket assignees from state
+        #   3. Remove node        — graph mutation
+        #   4. Centrality vacuum  — diff before/after centrality, apply stress
+
+        self._handoff_active_incidents(name, dept_lead, record, day, date_str, state)
+        self._reassign_jira_tickets(name, dept_lead, record, day, date_str, state)
+
+        G.remove_node(name)
+        self._gd._centrality_dirty = True
+        self._gd._stress.pop(name, None)
+
+        self._apply_centrality_vacuum(centrality_before, name, day, date_str)
+
+        # Mutate org-level collections
+        if dept in self._org_chart and name in self._org_chart[dept]:
+            self._org_chart[dept].remove(name)
+        if name in self._all_names:
+            self._all_names.remove(name)
+        self._personas.pop(name, None)
+        self._departed.append(record)
+
+        if not hasattr(state, "departed_employees"):
+            state.departed_employees = {}
+        state.departed_employees[name] = {
+            "left":           date_str,
+            "role":           dep_cfg.get("role", "Engineer"),
+            "knew_about":     record.knowledge_domains,
+            "documented_pct": record.documented_pct,
+        }
+
+        self._schedule_backfill(record, day)
+
+        self._mem.log_event(SimEvent(
+            type="employee_departed", day=day, date=date_str,
+            actors=[name], artifact_ids={},
+            facts={
+                "name":                 name,
+                "dept":                 dept,
+                "reason":               record.reason,
+                "knowledge_domains":    record.knowledge_domains,
+                "documented_pct":       record.documented_pct,
+                "peak_stress":          peak_stress,
+                "centrality":           round(departing_centrality, 4),
+                "strongest_bonds":      sorted(
+                    edge_snapshot.items(), key=lambda x: x[1], reverse=True
+                )[:3],
+                "tickets_reassigned":   record.reassigned_tickets,
+                "incidents_handed_off": record.incident_handoffs,
+                "scheduled":            scheduled,
+            },
+            summary=(
+                f"{name} ({dept}) departed Day {day} [{record.reason}]. "
+                + (f"Gaps: {', '.join(record.knowledge_domains)}. " if record.knowledge_domains else "")
+                + f"~{int(record.documented_pct*100)}% documented. "
+                + (f"Reassigned {len(record.reassigned_tickets)} ticket(s). " if record.reassigned_tickets else "")
+                + (f"Handed off {len(record.incident_handoffs)} incident(s)." if record.incident_handoffs else "")
+            ),
+            tags=["employee_departed", "lifecycle", dept.lower()],
+        ))
+
+        logger.info(
+            f"  [red]👋 Departure:[/red] {name} ({dept}) [{record.reason}]. "
+            f"{len(edge_snapshot)} edges severed. Centrality was {departing_centrality:.3f}."
+            + (f" Undocumented domains: {record.knowledge_domains}" if record.knowledge_domains else "")
+        )
+        return record
+    
+    # ── Side-effect 1: Incident handoff ──────────────────────────────────────
+
+    def _handoff_active_incidents(
+        self, name: str, dept_lead: str, record: DepartureRecord,
+        day: int, date_str: str, state
+    ) -> None:
+        """
+        For every active incident whose linked JIRA ticket is assigned to the
+        departing engineer, build a fresh Dijkstra path (while the node still
+        exists) and transfer ownership to the next person in the chain.
+        Falls back to dept_lead if no path exists.
+        """
+        for inc in state.active_incidents:
+            jira = next((t for t in state.jira_tickets if t.get("id") == inc.ticket_id), None)
+            if not jira or jira.get("assignee") != name:
+                continue
+
+            # Build chain while departing node is still in the graph
+            chain = self._gd.build_escalation_chain(
+                first_responder=name,
+                domain_keywords=record.knowledge_domains or None,
+            )
+            new_owner = next((n for n, _ in chain.chain if n != name), dept_lead)
+
+            # Deterministic mutation — engine owns this, not the LLM
+            jira["assignee"] = new_owner
+            record.incident_handoffs.append(inc.ticket_id)
+
+            self._mem.log_event(SimEvent(
+                type="escalation_chain", day=day, date=date_str,
+                actors=[name, new_owner], artifact_ids={"jira": inc.ticket_id},
+                facts={
+                    "trigger":          "forced_handoff_on_departure",
+                    "departed":         name,
+                    "new_owner":        new_owner,
+                    "incident":         inc.ticket_id,
+                    "incident_stage":   inc.stage,
+                    "chain_used":       chain.chain,
+                    "chain_narrative":  self._gd.escalation_narrative(chain),
+                },
+                summary=(
+                    f"Incident {inc.ticket_id} (stage={inc.stage}) handed off "
+                    f"from departing {name} to {new_owner}. "
+                    f"Chain: {self._gd.escalation_narrative(chain)}"
+                ),
+                tags=["escalation_chain", "incident_handoff", "lifecycle"],
+            ))
+            logger.info(
+                f"    [cyan]🔀 Incident handoff:[/cyan] {inc.ticket_id} "
+                f"(stage={inc.stage}) {name} → {new_owner}"
+            )
+
+    # ── Side-effect 2: JIRA ticket reassignment ───────────────────────────────
+
+    def _reassign_jira_tickets(
+        self, name: str, dept_lead: str, record: DepartureRecord,
+        day: int, date_str: str, state
+    ) -> None:
+        """
+        Reassign all non-Done JIRA tickets owned by the departing engineer.
+
+        Status logic:
+          "To Do"        → stays "To Do", just new assignee
+          "In Progress"  with no linked PR → reset to "To Do" (new owner starts fresh)
+          "In Progress"  with linked PR    → keep status; PR review/merge closes it
+        """
+        for ticket in state.jira_tickets:
+            if ticket.get("assignee") != name or ticket.get("status") == "Done":
+                continue
+            # Skip tickets that were already handed off via incident handoff above
+            if ticket.get("id") in record.incident_handoffs:
+                # Assignee already updated — just log and continue
+                record.reassigned_tickets.append(ticket["id"])
+                continue
+
+            old_status      = ticket["status"]
+            ticket["assignee"] = dept_lead
+
+            if old_status == "In Progress" and not ticket.get("linked_prs"):
+                ticket["status"] = "To Do"
+
+            record.reassigned_tickets.append(ticket["id"])
+
+            self._mem.log_event(SimEvent(
+                type="ticket_progress", day=day, date=date_str,
+                actors=[name, dept_lead], artifact_ids={"jira": ticket["id"]},
+                facts={
+                    "ticket_id":    ticket["id"],
+                    "title":        ticket.get("title", ""),
+                    "old_assignee": name,
+                    "new_assignee": dept_lead,
+                    "old_status":   old_status,
+                    "new_status":   ticket["status"],
+                    "reason":       "departure_reassignment",
+                },
+                summary=(
+                    f"Ticket {ticket['id']} reassigned: {name} → {dept_lead} "
+                    f"(status: {old_status} → {ticket['status']})."
+                ),
+                tags=["ticket_reassignment", "lifecycle"],
+            ))
+
+        if record.reassigned_tickets:
+            logger.info(
+                f"    [yellow]📋 Reassigned:[/yellow] "
+                f"{', '.join(record.reassigned_tickets)} → {dept_lead}"
+            )
+
+    # ── Side-effect 3: Centrality vacuum ─────────────────────────────────────
+
+    def _apply_centrality_vacuum(
+        self,
+        centrality_before: Dict[str, float],
+        departed_name:     str,
+        day:               int,
+        date_str:          str,
+    ) -> None:
+        """
+        After the departed node is removed, force a fresh centrality computation.
+        Any remaining node whose score increased has absorbed bridging load —
+        it receives a proportional stress hit.
+
+          stress_delta = (c_after - c_before) * multiplier   [capped at 20]
+
+        This reflects the real organisational phenomenon: when a critical
+        connector leaves, the people who were adjacent to them suddenly become
+        the sole bridges across previously-separate clusters and feel the weight.
+        """
+        self._gd._centrality_dirty = True
+        centrality_after = self._gd._get_centrality()
+
+        multiplier = self._cfg.get("centrality_vacuum_stress_multiplier", 40)
+        max_hit    = 20
+
+        vacuum_affected: List[Tuple[str, float, int]] = []
+
+        for node, c_after in centrality_after.items():
+            delta = c_after - centrality_before.get(node, 0.0)
+            if delta <= 0:
+                continue
+            stress_hit = min(max_hit, int(delta * multiplier))
+            if stress_hit <= 0:
+                continue
+            self._gd._stress[node] = min(100, self._gd._stress.get(node, 30) + stress_hit)
+            vacuum_affected.append((node, round(delta, 4), stress_hit))
+
+        if not vacuum_affected:
+            return
+
+        vacuum_affected.sort(key=lambda x: x[2], reverse=True)
+        summary_str = ", ".join(
+            f"{n} +{s}pts (Δc={d})" for n, d, s in vacuum_affected[:5]
+        )
+
+        self._mem.log_event(SimEvent(
+            type="knowledge_gap_detected",   # closest existing type for RAG eval
+            day=day, date=date_str,
+            actors=[n for n, _, _ in vacuum_affected],
+            artifact_ids={},
+            facts={
+                "trigger":        "centrality_vacuum",
+                "departed":       departed_name,
+                "affected_nodes": [
+                    {"name": n, "centrality_delta": d, "stress_added": s}
+                    for n, d, s in vacuum_affected
+                ],
+            },
+            summary=(
+                f"Centrality vacuum after {departed_name}'s departure. "
+                f"Bridging load redistributed to: {summary_str}."
+            ),
+            tags=["centrality_vacuum", "lifecycle", "stress"],
+        ))
+        logger.info(
+            f"    [magenta]📈 Centrality vacuum:[/magenta] "
+            f"Stress absorbed by: {summary_str}"
+        )
+
+    # ─── HIRE ENGINE ──────────────────────────────────────────────────────────
+
+    def _execute_hire(
+        self, hire_cfg: dict, day: int, date_str: str, state
+    ) -> Optional[HireRecord]:
+        name = hire_cfg["name"]
+        dept = hire_cfg.get("dept", list(self._org_chart.keys())[0])
+        role = hire_cfg.get("role", "Engineer")
+        G    = self._gd.G
+
+        if name in G:
+            logger.warning(f"[lifecycle] '{name}' already in graph — skipping hire.")
+            return None
+
+        expertise = hire_cfg.get("expertise", ["general"])
+        style     = hire_cfg.get("style", "collaborative")
+        tenure    = hire_cfg.get("tenure", "new")
+        floor     = self._gd.cfg.get("edge_weight_floor", 0.5)
+
+        if dept not in self._org_chart:
+            self._org_chart[dept] = []
+        self._org_chart[dept].append(name)
+        if name not in self._all_names:
+            self._all_names.append(name)
+
+        self._personas[name] = {
+            "style": style, "expertise": expertise,
+            "tenure": tenure, "stress": 20,
+        }
+
+        G.add_node(name, dept=dept, is_lead=False, external=False, hire_day=day)
+        self._gd._stress[name] = 20
+        self._gd._centrality_dirty = True
+
+        # Same-dept peers get 2× floor; cross-dept gets floor.
+        # Both are below warmup_threshold so the planner naturally proposes 1on1s.
+        for other in list(G.nodes()):
+            if other == name:
+                continue
+            base_w = floor * 2.0 if G.nodes[other].get("dept") == dept else floor
+            G.add_edge(name, other, weight=round(base_w, 4))
+
+        record = HireRecord(
+            name=name, dept=dept, day=day, role=role,
+            expertise=expertise, style=style, tenure=tenure,
+        )
+        self._hired.append(record)
+
+        if not hasattr(state, "new_hires"):
+            state.new_hires = {}
+        state.new_hires[name] = {
+            "joined": date_str, "role": role,
+            "dept": dept, "expertise": expertise,
+        }
+
+        self._mem.log_event(SimEvent(
+            type="employee_hired", day=day, date=date_str,
+            actors=[name], artifact_ids={},
+            facts={
+                "name": name, "dept": dept, "role": role,
+                "expertise": expertise, "tenure": tenure,
+                "cold_start": True, "edge_weight_floor": floor,
+            },
+            summary=(
+                f"{name} joined {dept} as {role} on Day {day}. "
+                f"Cold-start edges at ω={floor}. Expertise: {', '.join(expertise)}."
+            ),
+            tags=["employee_hired", "lifecycle", dept.lower()],
+        ))
+        logger.info(
+            f"  [green]🎉 New hire:[/green] {name} → {dept} ({role}). "
+            f"Cold-start at ω={floor}. Expertise: {expertise}"
+        )
+        return record
+    
+    def _schedule_backfill(self, record: DepartureRecord, current_day: int) -> None:
+        """
+        If the departure reason warrants a backfill, inject a hire into
+        _scheduled_hires at a future day based on configurable lag.
+        """
+        backfill_cfg = self._cfg.get("backfill", {})
+        
+        # Which departure reasons trigger a backfill attempt
+        reasons_that_backfill = backfill_cfg.get(
+            "trigger_reasons", ["voluntary"]
+        )
+        if record.reason not in reasons_that_backfill:
+            return
+
+        # Layoffs explicitly blocked from backfill
+        if record.reason == "layoff":
+            return
+
+        lag_days = backfill_cfg.get("lag_days", 14)
+        hire_day  = current_day + lag_days
+
+        name = self._generate_backfill_name(dept=record.dept, role=record.role)
+        if name is None:
+            return
+
+        # Build a minimal hire config from the departing person's persona
+        departed_persona = self._personas.get(record.name, {})
+        backfill_hire = {
+            "name":      backfill_cfg.get("name_prefix", "NewHire") + f"_{hire_day}",
+            "dept":      record.dept,
+            "role":      record.role,
+            "expertise": departed_persona.get("expertise", ["general"]),
+            "style":     "still ramping up, asks frequent questions",
+            "tenure":    "new",
+            "day":       hire_day,
+            "_backfill_for": record.name,   # metadata only — for SimEvent logging
+        }
+
+        self._scheduled_hires.setdefault(hire_day, []).append(backfill_hire)
+
+        logger.info(
+            f"    [dim]📅 Backfill scheduled:[/dim] {record.dept} hire "
+            f"queued for Day {hire_day} (replacing {record.name})"
+        )
+
+    def _generate_backfill_name(self, dept: str, role: str) -> Optional[str]:
+        """
+        Ask the LLM for a single realistic first+last name for a new hire.
+        Retries up to 3 times if the name collides with an existing person.
+        Returns None if a unique name can't be produced — backfill is skipped.
+        """
+        if self._llm is None:
+            return None
+
+        forbidden = set(self._all_names) | {d.name for d in self._departed}
+        company   = self._cfg.get("company_name", "the company")
+
+        for attempt in range(3):
+            try:
+                from crewai import Agent, Task, Crew
+                agent = Agent(
+                    role="HR Coordinator",
+                    goal="Generate a realistic employee name.",
+                    backstory=(
+                        f"You work in HR at {company}. "
+                        f"You are onboarding a new {role} for the {dept} team."
+                    ),
+                    llm=self._llm,
+                )
+                task = Task(
+                    description=(
+                        f"Generate ONE realistic full name (first and last) for a new "
+                        f"{role} joining the {dept} team. "
+                        f"The name must not be any of: {sorted(forbidden)}. "
+                        f"Respond with ONLY the name — no punctuation, no explanation."
+                    ),
+                    expected_output="A single full name, e.g. 'Jordan Lee'.",
+                    agent=agent,
+                )
+                raw = str(Crew(agents=[agent], tasks=[task],
+                            verbose=False).kickoff()).strip()
+
+                # Strip any punctuation the LLM smuggled in
+                name = " ".join(raw.split())
+                name = "".join(c for c in name if c.isalpha() or c == " ").strip()
+
+                if not name or len(name.split()) < 2:
+                    continue
+                if name in forbidden:
+                    logger.info(
+                        f"    [dim]LLM proposed existing name '{name}', retrying...[/dim]"
+                    )
+                    continue
+
+                return name
+
+            except Exception as e:
+                logger.warning(f"[lifecycle] Name generation attempt {attempt+1} failed: {e}")
+
+        logger.warning(
+            f"[lifecycle] Could not generate a unique backfill name for {dept} "
+            f"after 3 attempts. Backfill skipped."
+        )
+        return None
+
+    # ─── Private helpers ──────────────────────────────────────────────────────
+
+    def _count_warm_edges(self, hire: HireRecord) -> int:
+        G = self._gd.G
+        if not G.has_node(hire.name):
+            return 0
+        return sum(
+            1 for nb in G.neighbors(hire.name)
+            if G[hire.name][nb].get("weight", 0) >= hire.warmup_threshold
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HELPERS — called from flow.py
+# ─────────────────────────────────────────────────────────────────────────────
+
+def patch_validator_for_lifecycle(validator, lifecycle_mgr: OrgLifecycleManager) -> None:
+    """Sync PlanValidator._valid_actors with the current live roster."""
+    for name in lifecycle_mgr.departed_names():
+        validator._valid_actors.discard(name)
+    for name in lifecycle_mgr.new_hire_names():
+        validator._valid_actors.add(name)
+
+
+def recompute_escalation_after_departure(
+    graph_dynamics:  GraphDynamics,
+    departed:        DepartureRecord,
+    first_responder: str,
+) -> str:
+    """
+    Rebuild escalation chain post-departure and return a log-ready narrative.
+    The node has already been removed, so Dijkstra routes around the gap.
+    """
+    chain = graph_dynamics.build_escalation_chain(
+        first_responder=first_responder,
+        domain_keywords=departed.knowledge_domains or None,
+    )
+    narrative = graph_dynamics.escalation_narrative(chain)
+    note = f"[Post-departure re-route after {departed.name} left] Path: {narrative}"
+    logger.info(f"    [cyan]🔀 Escalation re-routed:[/cyan] {note}")
+    return note

--- a/src/plan_validator.py
+++ b/src/plan_validator.py
@@ -27,6 +27,7 @@ from planner_models import (
 
 logger = logging.getLogger("orgforge.validator")
 
+_DEPARTED_NAMES: set = set()
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PLAUSIBILITY RULES
@@ -53,6 +54,9 @@ _COOLDOWN_DAYS: Dict[str, int] = {
     "hr_checkin":           3,
     "leadership_sync":      2,
     "vendor_meeting":       3,
+    "onboarding_session":   1,
+    "farewell_message":   999,
+    "warmup_1on1":          2,
 }
 
 
@@ -146,6 +150,19 @@ class PlanValidator:
                 approved=False, event=event,
                 rejection_reason=f"Unknown actors: {unknown_actors}. "
                                  f"LLM invented names not in org_chart.",
+            )
+        
+        # ── 1b. Departed-actor guard ──────────────────────────────────────────
+        # patch_validator_for_lifecycle() keeps _valid_actors pruned,
+        # but this explicit check gives a clearer rejection message.
+        departed_actors = [a for a in event.actors if a in _DEPARTED_NAMES]
+        if departed_actors:
+            return ValidationResult(
+                approved=False, event=event,
+                rejection_reason=(
+                    f"Actors {departed_actors} have departed the organisation. "
+                    f"Remove them from this event."
+                ),
             )
 
         # ── 2. Novel event type ───────────────────────────────────────────────

--- a/src/planner_models.py
+++ b/src/planner_models.py
@@ -95,6 +95,16 @@ class CrossDeptSignal:
     day:          int
     relevance:    str   # "direct" | "indirect" — how strongly it shapes today
 
+@dataclass
+class LifecycleContext:
+    """
+    Recent hire/departure activity surfaced to the DepartmentPlanner.
+    Included in the roster section of the planning prompt so the LLM
+    can propose onboarding_session or warmup_1on1 events naturally.
+    """
+    recent_departures: List[Dict[str, Any]]   # [{name, dept, day, domains}]
+    recent_hires:      List[Dict[str, Any]]   # [{name, dept, day, role}]
+    active_gaps:       List[str]              # knowledge domain strings still unresolved
 
 @dataclass
 class ProposedEvent:
@@ -188,4 +198,6 @@ KNOWN_EVENT_TYPES = {
     "external_contact_summarized", "vendor_meeting", "customer_escalation",
     # Org
     "normal_day_slack", "confluence_created", "day_summary",
+    "employee_departed", "employee_hired", "knowledge_gap_detected",
+    "onboarding_session", "farewell_message", "warmup_1on1",
 }

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,652 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from flow import Flow, ActiveIncident
+from memory import SimEvent
+from org_lifecycle import OrgLifecycleManager, patch_validator_for_lifecycle
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FIXTURES
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_flow():
+    """Flow instance with mocked LLMs and DB, extended with lifecycle manager."""
+    with patch("flow.build_llm"), patch("flow.Memory"):
+        flow = Flow()
+        flow.state.day = 5
+        flow.state.system_health = 80
+        return flow
+
+
+@pytest.fixture
+def lifecycle(mock_flow):
+    """
+    Standalone OrgLifecycleManager wired to the flow's live graph and state.
+    Mirrors the setup in Flow.__init__ per the patch guide.
+    """
+    org_chart = {"Engineering": ["Alice", "Bob", "Carol"]}
+    personas  = {
+        "Alice": {"style": "direct", "expertise": ["backend"], "tenure": "3y", "stress": 30},
+        "Bob":   {"style": "casual", "expertise": ["infra"],   "tenure": "2y", "stress": 25},
+        "Carol": {"style": "quiet",  "expertise": ["frontend"],"tenure": "1y", "stress": 20},
+    }
+    all_names = ["Alice", "Bob", "Carol"]
+    leads     = {"Engineering": "Alice"}
+
+    # Build a fresh graph that matches the org_chart above
+    import networkx as nx
+    from graph_dynamics import GraphDynamics
+    G = nx.Graph()
+    for name in all_names:
+        G.add_node(name, dept="Engineering", is_lead=(name == "Alice"), external=False)
+    for i, a in enumerate(all_names):
+        for b in all_names[i + 1:]:
+            G.add_edge(a, b, weight=5.0)
+
+    config = {
+        "org_lifecycle": {
+            "centrality_vacuum_stress_multiplier": 40,
+            "enable_random_attrition": False,
+        },
+        "graph_dynamics": {},
+        "personas": {n: personas[n] for n in all_names},
+        "org_chart": org_chart,
+        "leads": leads,
+    }
+    gd = GraphDynamics(G, config)
+
+    mgr = OrgLifecycleManager(
+        config=config,
+        graph_dynamics=gd,
+        mem=mock_flow._mem,
+        org_chart=org_chart,
+        personas=personas,
+        all_names=all_names,
+        leads=leads,
+    )
+    return mgr, gd, org_chart, all_names, mock_flow.state
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. JIRA TICKET REASSIGNMENT
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_departure_reassigns_open_tickets(lifecycle):
+    """
+    Verifies that non-Done JIRA tickets owned by a departing engineer are
+    reassigned to the dept lead and reset to 'To Do' when no PR is linked.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    state.jira_tickets = [
+        {"id": "ORG-101", "title": "Fix retry logic", "status": "In Progress",
+         "assignee": "Bob", "linked_prs": []},
+        {"id": "ORG-102", "title": "Write docs",      "status": "To Do",
+         "assignee": "Bob", "linked_prs": []},
+        {"id": "ORG-103", "title": "Already done",    "status": "Done",
+         "assignee": "Bob", "linked_prs": []},
+    ]
+    state.active_incidents = []
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    t101 = next(t for t in state.jira_tickets if t["id"] == "ORG-101")
+    t102 = next(t for t in state.jira_tickets if t["id"] == "ORG-102")
+    t103 = next(t for t in state.jira_tickets if t["id"] == "ORG-103")
+
+    # In Progress with no PR → reset to To Do, reassigned to lead
+    assert t101["assignee"] == "Alice"
+    assert t101["status"]   == "To Do"
+
+    # To Do → stays To Do, reassigned to lead
+    assert t102["assignee"] == "Alice"
+    assert t102["status"]   == "To Do"
+
+    # Done → untouched
+    assert t103["assignee"] == "Bob"
+
+
+def test_departure_preserves_in_progress_ticket_with_pr(lifecycle):
+    """
+    An 'In Progress' ticket that already has a linked PR must keep its status
+    so the existing PR review/merge flow can close it naturally.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    state.jira_tickets = [
+        {"id": "ORG-200", "title": "Hot fix", "status": "In Progress",
+         "assignee": "Bob", "linked_prs": ["PR-101"]},
+    ]
+    state.active_incidents = []
+
+    dep_cfg = {"name": "Bob", "reason": "layoff", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    t200 = next(t for t in state.jira_tickets if t["id"] == "ORG-200")
+    assert t200["assignee"] == "Alice"
+    assert t200["status"]   == "In Progress"   # status preserved
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. ACTIVE INCIDENT HANDOFF
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_departure_hands_off_active_incident(lifecycle):
+    """
+    When a departing engineer owns an active incident's JIRA ticket, ownership
+    must transfer to another person before the node is removed.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    state.jira_tickets = [
+        {"id": "ORG-300", "title": "DB outage", "status": "In Progress",
+         "assignee": "Bob", "linked_prs": []},
+    ]
+    state.active_incidents = [
+        ActiveIncident(ticket_id="ORG-300", title="DB outage",
+                       day_started=4, stage="investigating", root_cause="OOM"),
+    ]
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    t300 = next(t for t in state.jira_tickets if t["id"] == "ORG-300")
+    # Bob is gone — ticket must now belong to someone still in the graph
+    assert t300["assignee"] != "Bob"
+    assert t300["assignee"] in all_names or t300["assignee"] == "Alice"
+
+
+def test_handoff_emits_escalation_chain_simevent(lifecycle):
+    """
+    The forced handoff must emit an escalation_chain SimEvent with
+    trigger='forced_handoff_on_departure' so the ground-truth log is accurate.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    state.jira_tickets = [
+        {"id": "ORG-301", "title": "API down", "status": "In Progress",
+         "assignee": "Carol", "linked_prs": []},
+    ]
+    state.active_incidents = [
+        ActiveIncident(ticket_id="ORG-301", title="API down",
+                       day_started=4, stage="detected", root_cause="timeout"),
+    ]
+
+    dep_cfg = {"name": "Carol", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.8, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    logged_types = [call.args[0].type for call in mgr._mem.log_event.call_args_list]
+    assert "escalation_chain" in logged_types
+
+    escalation_event = next(
+        call.args[0] for call in mgr._mem.log_event.call_args_list
+        if call.args[0].type == "escalation_chain"
+    )
+    assert escalation_event.facts["trigger"] == "forced_handoff_on_departure"
+    assert escalation_event.facts["departed"] == "Carol"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. CENTRALITY VACUUM
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_centrality_vacuum_stresses_neighbours(lifecycle):
+    """
+    Removing a bridge shortcut node should increase stress on remaining nodes
+    that absorb its rerouted traffic.
+
+    Topology: outer ring Alice-Carol-Dave-Eve-Alice, with Bob as an internal
+    shortcut between Alice and Dave. Removing Bob keeps the ring intact but
+    forces Alice-Dave traffic through Carol and Eve, increasing their
+    betweenness and triggering vacuum stress.
+    """
+    import networkx as nx
+    from graph_dynamics import GraphDynamics
+
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    ring_nodes = ["Alice", "Bob", "Carol", "Dave", "Eve"]
+    G = nx.Graph()
+    for name in ring_nodes:
+        G.add_node(name, dept="Engineering", is_lead=(name == "Alice"), external=False)
+
+    # Outer ring — stays connected after Bob is removed
+    G.add_edge("Alice", "Carol", weight=5.0)
+    G.add_edge("Carol", "Dave",  weight=5.0)
+    G.add_edge("Dave",  "Eve",   weight=5.0)
+    G.add_edge("Eve",   "Alice", weight=5.0)
+    # Bob is an internal shortcut — high centrality, but not the only path
+    G.add_edge("Alice", "Bob",   weight=5.0)
+    G.add_edge("Bob",   "Dave",  weight=5.0)
+
+    config = {
+        "org_lifecycle": {"centrality_vacuum_stress_multiplier": 40},
+        "graph_dynamics": {},
+        "personas": {n: {"stress": 25} for n in ring_nodes},
+        "org_chart": {"Engineering": ring_nodes},
+        "leads": {"Engineering": "Alice"},
+    }
+    gd_ring = GraphDynamics(G, config)
+    for name in ring_nodes:
+        gd_ring._stress[name] = 25
+
+    mgr._gd        = gd_ring
+    mgr._org_chart = {"Engineering": list(ring_nodes)}
+    mgr._all_names = list(ring_nodes)
+    mgr._leads     = {"Engineering": "Alice"}
+
+    remaining = ["Alice", "Carol", "Dave", "Eve"]
+    stress_before = {n: gd_ring._stress.get(n, 25) for n in remaining}
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    stress_increased = any(
+        gd_ring._stress.get(n, 0) > stress_before[n]
+        for n in remaining
+        if gd_ring.G.has_node(n)
+    )
+    assert stress_increased
+
+
+def test_centrality_vacuum_stress_capped_at_20(lifecycle):
+    """
+    The per-departure stress cap of 20 points must never be exceeded regardless
+    of how extreme the centrality shift is.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    # Force a very high multiplier to stress-test the cap
+    mgr._cfg["centrality_vacuum_stress_multiplier"] = 10_000
+
+    stress_before = {n: gd._stress.get(n, 30) for n in all_names}
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    for name in ["Alice", "Carol"]:
+        if not gd.G.has_node(name):
+            continue
+        delta = gd._stress.get(name, 0) - stress_before.get(name, 30)
+        assert delta <= 20, f"{name} stress delta {delta} exceeded cap of 20"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. NODE REMOVAL & GRAPH INTEGRITY
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_departed_node_removed_from_graph(lifecycle):
+    """The departing engineer's node must not exist in the graph after departure."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    assert gd.G.has_node("Bob")
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    assert not gd.G.has_node("Bob")
+    assert "Bob" not in all_names
+    assert "Bob" not in org_chart.get("Engineering", [])
+
+
+def test_departed_node_stress_entry_removed(lifecycle):
+    """The departing engineer's stress entry must be cleaned up from GraphDynamics."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    gd._stress["Bob"] = 55
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    assert "Bob" not in gd._stress
+
+
+def test_departure_emits_employee_departed_simevent(lifecycle):
+    """A departure must emit exactly one employee_departed SimEvent."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    dep_cfg = {"name": "Bob", "reason": "layoff", "role": "Engineer",
+               "knowledge_domains": ["auth-service"], "documented_pct": 0.2, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    departed_events = [
+        call.args[0] for call in mgr._mem.log_event.call_args_list
+        if call.args[0].type == "employee_departed"
+    ]
+    assert len(departed_events) == 1
+    evt = departed_events[0]
+    assert evt.facts["name"]   == "Bob"
+    assert evt.facts["reason"] == "layoff"
+    assert "auth-service" in evt.facts["knowledge_domains"]
+
+
+def test_departure_record_stored_on_state(lifecycle):
+    """state.departed_employees must be populated after a departure."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Senior Engineer",
+               "knowledge_domains": ["redis-cache"], "documented_pct": 0.4, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    assert "Bob" in state.departed_employees
+    assert state.departed_employees["Bob"]["role"] == "Senior Engineer"
+    assert "redis-cache" in state.departed_employees["Bob"]["knew_about"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. KNOWLEDGE GAP SCANNING
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_knowledge_gap_scan_detects_domain_hit(lifecycle):
+    """
+    scan_for_knowledge_gaps must emit a knowledge_gap_detected SimEvent when
+    the incident root cause mentions a departed employee's known domain.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    # First, register a departure with known domains
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": ["auth-service", "redis-cache"],
+               "documented_pct": 0.25, "day": 3}
+    mgr._scheduled_departures = {3: [dep_cfg]}
+    mgr.process_departures(day=3, date_str="2026-01-03", state=state)
+    mgr._mem.log_event.reset_mock()
+
+    # Now trigger a scan with text that mentions the domain
+    gaps = mgr.scan_for_knowledge_gaps(
+        text="Root cause: auth-service JWT validation failing after config change.",
+        triggered_by="ORG-400",
+        day=5,
+        date_str="2026-01-05",
+        state=state,
+    )
+
+    assert len(gaps) == 1
+    assert gaps[0].domain_hit       == "auth-service"
+    assert gaps[0].departed_name    == "Bob"
+    assert gaps[0].triggered_by     == "ORG-400"
+    assert gaps[0].documented_pct   == 0.25
+
+    gap_events = [
+        call.args[0] for call in mgr._mem.log_event.call_args_list
+        if call.args[0].type == "knowledge_gap_detected"
+    ]
+    assert len(gap_events) == 1
+
+
+def test_knowledge_gap_scan_deduplicates(lifecycle):
+    """
+    The same domain must only surface once per simulation run regardless of
+    how many times the text is scanned.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": ["redis-cache"], "documented_pct": 0.5, "day": 3}
+    mgr._scheduled_departures = {3: [dep_cfg]}
+    mgr.process_departures(day=3, date_str="2026-01-03", state=state)
+    mgr._mem.log_event.reset_mock()
+
+    text = "redis-cache connection pool exhausted"
+    mgr.scan_for_knowledge_gaps(text=text, triggered_by="ORG-401",
+                                day=5, date_str="2026-01-05", state=state)
+    mgr.scan_for_knowledge_gaps(text=text, triggered_by="ORG-402",
+                                day=6, date_str="2026-01-06", state=state)
+
+    gap_events = [
+        call.args[0] for call in mgr._mem.log_event.call_args_list
+        if call.args[0].type == "knowledge_gap_detected"
+    ]
+    assert len(gap_events) == 1   # second scan must be a no-op
+
+
+def test_knowledge_gap_scan_no_false_positives(lifecycle):
+    """Unrelated text must not trigger any knowledge gap events."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": ["auth-service"], "documented_pct": 0.5, "day": 3}
+    mgr._scheduled_departures = {3: [dep_cfg]}
+    mgr.process_departures(day=3, date_str="2026-01-03", state=state)
+    mgr._mem.log_event.reset_mock()
+
+    gaps = mgr.scan_for_knowledge_gaps(
+        text="Disk I/O throughput degraded on worker-node-3.",
+        triggered_by="ORG-403",
+        day=5, date_str="2026-01-05", state=state,
+    )
+    assert len(gaps) == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. NEW HIRE COLD START
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_new_hire_added_to_graph(lifecycle):
+    """A hired engineer must appear in the graph and org_chart after process_hires."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python", "Kafka"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    assert gd.G.has_node("Taylor")
+    assert "Taylor" in org_chart["Engineering"]
+    assert "Taylor" in all_names
+
+
+def test_new_hire_cold_start_edges(lifecycle):
+    """
+    All edges for a new hire must start at or below floor × 2, ensuring they
+    sit below warmup_threshold (2.0) so the planner proposes onboarding events.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+    floor = gd.cfg["edge_weight_floor"]
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    for nb in gd.G.neighbors("Taylor"):
+        weight = gd.G["Taylor"][nb]["weight"]
+        assert weight <= floor * 2.0, (
+            f"Taylor→{nb} edge weight {weight} exceeds cold-start ceiling {floor * 2.0}"
+        )
+
+
+def test_new_hire_warm_up_edge(lifecycle):
+    """warm_up_edge must increase the edge weight between the hire and a colleague."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    weight_before = gd.G["Taylor"]["Alice"]["weight"]
+    mgr.warm_up_edge("Taylor", "Alice", boost=1.5)
+    weight_after  = gd.G["Taylor"]["Alice"]["weight"]
+
+    assert weight_after == round(weight_before + 1.5, 4)
+
+
+def test_new_hire_emits_simevent(lifecycle):
+    """process_hires must emit an employee_hired SimEvent with correct facts."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python", "Kafka"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    hired_events = [
+        call.args[0] for call in mgr._mem.log_event.call_args_list
+        if call.args[0].type == "employee_hired"
+    ]
+    assert len(hired_events) == 1
+    evt = hired_events[0]
+    assert evt.facts["name"]       == "Taylor"
+    assert evt.facts["cold_start"] is True
+    assert "Kafka" in evt.facts["expertise"]
+
+
+def test_new_hire_stress_initialised_low(lifecycle):
+    """New hires must start with a low stress score, not inherit the org average."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    assert gd._stress.get("Taylor", 0) == 20
+
+
+def test_new_hire_record_stored_on_state(lifecycle):
+    """state.new_hires must be populated with the hire's metadata."""
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    assert hasattr(state, "new_hires")
+    assert "Taylor" in state.new_hires
+    assert state.new_hires["Taylor"]["role"] == "Backend Engineer"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. VALIDATOR PATCH
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_patch_validator_removes_departed_actor(lifecycle):
+    """
+    After a departure, patch_validator_for_lifecycle must remove the departed
+    name from PlanValidator._valid_actors so the actor integrity check holds.
+    """
+    from plan_validator import PlanValidator
+
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    validator = PlanValidator(
+        all_names=list(all_names),
+        external_contact_names=[],
+        config={},
+    )
+    assert "Bob" in validator._valid_actors
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
+    mgr._scheduled_departures = {5: [dep_cfg]}
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+
+    patch_validator_for_lifecycle(validator, mgr)
+
+    assert "Bob" not in validator._valid_actors
+
+
+def test_patch_validator_adds_new_hire(lifecycle):
+    """
+    After a hire, patch_validator_for_lifecycle must add the new name to
+    PlanValidator._valid_actors so the planner can propose events with them.
+    """
+    from plan_validator import PlanValidator
+
+    mgr, gd, org_chart, all_names, state = lifecycle
+
+    validator = PlanValidator(
+        all_names=list(all_names),
+        external_contact_names=[],
+        config={},
+    )
+    assert "Taylor" not in validator._valid_actors
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    patch_validator_for_lifecycle(validator, mgr)
+
+    assert "Taylor" in validator._valid_actors
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. ROSTER CONTEXT
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_get_roster_context_reflects_departure_and_hire(lifecycle):
+    """
+    get_roster_context must surface both a recent departure and a recent hire
+    so DepartmentPlanner prompts reflect actual roster state.
+    """
+    mgr, gd, org_chart, all_names, state = lifecycle
+    state.jira_tickets     = []
+    state.active_incidents = []
+
+    dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
+               "knowledge_domains": ["redis-cache"], "documented_pct": 0.3, "day": 4}
+    mgr._scheduled_departures = {4: [dep_cfg]}
+    mgr.process_departures(day=4, date_str="2026-01-04", state=state)
+
+    hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
+                "expertise": ["Python"], "style": "methodical", "tenure": "new",
+                "day": 5}
+    mgr._scheduled_hires = {5: [hire_cfg]}
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+
+    context = mgr.get_roster_context()
+
+    assert "Bob"     in context
+    assert "Taylor"  in context
+    assert "redis-cache" in context


### PR DESCRIPTION
This PR makes the org chart a living thing. Engineers depart mid-simulation, tickets get orphaned and reassigned, knowledge gaps surface in real incidents, new hires start cold and warm up through collaboration, and the engine can automatically schedule a backfill hire after a departure. Every side-effect is deterministic — the LLM is only called once, to generate a backfill name.

---

### What changed

**`org_lifecycle.py`** _(new)_
The single authority for all dynamic roster mutations. LLM usage is intentionally minimal — `_generate_backfill_name()` is the only LLM call; everything else is engine-controlled.

Three public entry points called from `flow.py` before planning runs each day:
- `process_departures()` — fires scheduled and random attrition departures; executes three deterministic side-effects in strict order before removing the node
- `process_hires()` — adds new engineer nodes at `edge_weight_floor`, bootstraps a persona, emits `employee_hired` SimEvent
- `scan_for_knowledge_gaps()` — scans incident root causes and Confluence pages against all departed employees' `knowledge_domains`; emits `knowledge_gap_detected` SimEvent on first hit per domain, deduplicated across the full run

**Departure side-effects (in execution order):**

1. **Active incident handoff** — before the node is removed, every active incident whose JIRA ticket is assigned to the departing engineer triggers a Dijkstra escalation chain while the node is still present. Ownership transfers to the first non-departing person in the chain; falls back to dept lead if no path exists. Emits `escalation_chain` SimEvent with `trigger: "forced_handoff_on_departure"`.

2. **JIRA ticket reassignment** — all non-Done tickets are reassigned to the dept lead. `"In Progress"` tickets with no linked PR are reset to `"To Do"` so the new owner starts fresh. `"In Progress"` tickets with a linked PR keep their status so the existing review/merge flow closes them naturally. Tickets already handled by the incident handoff are not double-logged.

3. **Centrality vacuum stress** — after node removal, betweenness centrality is recomputed and diffed against the pre-departure snapshot. Nodes whose score increased have absorbed bridging load and receive `stress_delta = Δc × multiplier` (default `40`, configurable, hard-capped at `20` points per departure).

**Backfill scheduling:**
Configurable via `org_lifecycle.backfill`. When a departure reason matches `trigger_reasons` (default `["voluntary"]`), a future hire is injected into `_scheduled_hires` at `current_day + lag_days` (default `14`). The backfill name is generated by the worker LLM with up to 3 retries on collision; if a unique name can't be produced the backfill is silently skipped. The new hire's role, dept, and expertise are derived from the departing engineer's `DepartureRecord` — not hardcoded.

**Random attrition:**
Opt-in via `enable_random_attrition: true`. Every non-lead employee has a configurable daily departure probability. A `min_dept_size` guard prevents departments from being hollowed out below a safe threshold (default `2` non-leads). At most one random departure fires per day.

**`planner_models.py`**
`DepartureRecord` gains a `role` field. `KNOWN_EVENT_TYPES` extended with `employee_departed`, `employee_hired`, `knowledge_gap_detected`, `onboarding_session`, `farewell_message`, `warmup_1on1`.

**`flow.py`**
- `ORG_CHART` and `PERSONAS` copied into mutable `LIVE_ORG_CHART` / `LIVE_PERSONAS` at startup; all roster-sensitive paths reference the live copies
- `State` gains `departed_employees` and `new_hires` fields
- `OrgLifecycleManager` instantiated in `Flow.__init__` with `worker_llm=WORKER_MODEL`
- `process_departures()` / `process_hires()` called at the top of `daily_cycle` before planning runs
- `scan_for_knowledge_gaps()` called in `_handle_incident()` after `root_cause` is generated — both the dynamic scan and the existing `involves_gap` check now run against `root_cause` rather than `daily_theme` for consistency
- `simulation_snapshot.json` extended with `departed_employees`, `new_hires`, and `knowledge_gap_events`

**`day_planner.py`**
`DayPlannerOrchestrator` holds a `validator` reference patched daily via `patch_validator_for_lifecycle()`. `DepartmentPlanner` accepts `lifecycle_context` injected between cross-dept signals and known event types so the LLM plan reflects actual roster state.

---

### The LLM boundary holds

One LLM call was added: `_generate_backfill_name()` in `org_lifecycle.py`. It generates a name string only — the engine validates uniqueness, decides whether to accept it, and owns all state mutation. LLMs still never write to the SimEvent log or mutate State directly.

---
### Config additions

```yaml
org_lifecycle:
  scheduled_departures:
    - name: "Jordan"
      day: 12
      reason: "voluntary"  # voluntary | layoff | performance
      role: "Senior Backend Engineer"
      knowledge_domains: ["auth-service", "redis-cache"]
      documented_pct: 0.25
  scheduled_hires:
    - name: "Taylor"
      day: 15
      dept: "Engineering"
      role: "Backend Engineer"
      expertise: ["Python", "FastAPI"]
      style: "methodical, asks lots of questions"
      tenure: "new"
  backfill:
    trigger_reasons: ["voluntary", "performance"]
    lag_days: 14
  enable_random_attrition: false
  random_attrition_daily_prob: 0.005
  min_dept_size: 2
  centrality_vacuum_stress_multiplier: 40
```
