### PR TITLE
Implement actor-local simulation clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [v0.3.4] — 2026-03-05
+
+### Added
+
+- `sim_clock.py` — Actor-local simulation clock replacing all `random.randint`
+  timestamp generation across `flow.py` and `normal_day.py`. Each employee now
+  has an independent time cursor, guaranteeing no individual can have two
+  overlapping artifacts and allowing genuine parallel activity across the org.
+
+- `SimClock.advance_actor()` — Ambient work primitive. Advances a single actor's
+  cursor by `estimated_hrs` and returns a randomly sampled artifact timestamp
+  from within that work block. Used for ticket progress, Confluence pages, and
+  deep work sessions where no causal ordering exists between actors.
+
+- `SimClock.sync_and_tick()` — Causal work primitive. Synchronizes all
+  participating actors to the latest cursor among them (the thread cannot start
+  until the busiest person is free), then ticks forward by a random delta.
+  Used for incident response chains, escalations, and PR review threads.
+
+- `SimClock.tick_message()` — Per-message Slack cadence ticker. Wraps
+  `sync_and_tick` with cadence hints: `"incident"` (1–4 min), `"normal"`
+  (3–12 min), `"async"` (10–35 min). Replaces the flat random hour assignment
+  in `_parse_slack_messages()` so messages within a thread are always
+  chronologically ordered and realistically spaced.
+
+- `SimClock.tick_system()` — Independent cursor for automated bot alerts
+  (Datadog, PagerDuty, GitHub Actions). Advances separately from human actors
+  so bot messages are never gated by an individual's availability.
+
+- `SimClock.sync_to_system()` — Incident response helper. Pulls on-call and
+  incident lead cursors forward to the system clock when a P1 fires, ensuring
+  all human response artifacts are stamped after the triggering alert.
+
+- `SimClock.at()` — Scheduled meeting pin. Stamps an artifact at the declared
+  meeting time and advances all attendee cursors to the meeting end. Used for
+  standup (09:30), sprint planning, and retrospectives.
+
+- `SimClock.schedule_meeting()` — Randomized ceremony scheduler. Picks a
+  random slot within a defined window (e.g. sprint planning 09:30–11:00,
+  retro 14:00–16:00) and pins all attendees via `at()`.
+
+- `SimClock.sync_and_advance()` — Multi-actor ambient work primitive. Syncs
+  participants to the latest cursor then advances all by a shared duration.
+  Used for collaborative work blocks like pair programming or design sessions.
+
+### Fixed
+
+- Timestamps across Slack threads, JIRA comments, Confluence pages, bot alerts,
+  and external contact summaries were previously generated with independent
+  `random.randint(hour, ...)` calls, producing out-of-order and causally
+  inconsistent artifact timelines. All timestamp generation now routes through
+  `SimClock`, restoring correct forensic ordering throughout the corpus.
+
+---
+
 ## [v0.3.3] — 2026-03-05
 
 ### Changed

--- a/src/day_planner.py
+++ b/src/day_planner.py
@@ -41,6 +41,12 @@ from plan_validator import PlanValidator
 
 logger = logging.getLogger("orgforge.planner")
 
+def _coerce_collaborators(raw) -> List[str]:
+    """Normalize LLM collaborator output — handles str, list, or None."""
+    if not raw:
+        return []
+    return raw if isinstance(raw, list) else [raw]
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # DEPARTMENT PLANNER
@@ -111,7 +117,7 @@ class DepartmentPlanner:
             "activity_type": "string",
             "description": "string",
             "related_id": "string or null",
-            "collaborator": "string or null",
+            "collaborator": ["string"],
             "estimated_hrs": float
             }}
         ]
@@ -248,7 +254,7 @@ class DepartmentPlanner:
                     activity_type=a.get("activity_type", "ticket_progress"),
                     description=a.get("description", ""),
                     related_id=a.get("related_id"),
-                    collaborator=a.get("collaborator"),
+                    collaborator=_coerce_collaborators(a.get("collaborator")),
                     estimated_hrs=float(a.get("estimated_hrs", 2.0)),
                 )
                 for a in ep.get("agenda", [])
@@ -636,7 +642,8 @@ class DayPlannerOrchestrator:
         state,
         mem:            Memory,
         graph_dynamics: GraphDynamics,
-        lifecycle_context: str = "",
+        clock,
+        lifecycle_context: str = ""
     ) -> OrgDayPlan:
         """
         Full planning pass for one day.
@@ -644,9 +651,10 @@ class DayPlannerOrchestrator:
         """
         day  = state.day
         date = str(state.current_date.date())
+        system_time_iso = clock.now("system").isoformat() # This will be 09:00:00
 
         # ── Generate org theme (lightweight — replaces _generate_theme()) ─────
-        org_theme = self._generate_org_theme(state, mem)
+        org_theme = self._generate_org_theme(state, mem, clock)
 
         # ── Build cross-dept signals from recent SimEvents ────────────────────
         cross_signals_by_dept = self._extract_cross_signals(mem, day)
@@ -705,6 +713,7 @@ class DayPlannerOrchestrator:
         for r in self._validator.rejected(results):
             mem.log_event(SimEvent(
                 type="proposed_event_rejected",
+                timestamp=system_time_iso,
                 day=day, date=date,
                 actors=r.event.actors,
                 artifact_ids={},
@@ -722,6 +731,7 @@ class DayPlannerOrchestrator:
         for novel in self._validator.drain_novel_log():
             mem.log_event(SimEvent(
                 type="novel_event_proposed",
+                timestamp=system_time_iso,
                 day=day, date=date,
                 actors=novel.actors,
                 artifact_ids={},
@@ -749,11 +759,12 @@ class DayPlannerOrchestrator:
 
     # ─── Helpers ─────────────────────────────────────────────────────────────
 
-    def _generate_org_theme(self, state, mem: Memory) -> str:
+    def _generate_org_theme(self, state, mem: Memory, clock) -> str:
         """Lightweight replacement for _generate_theme() in flow.py."""
+        system_time_iso = clock.now("system").isoformat()
         ctx = mem.context_for_prompt(
             f"day {state.day} system health sprint incidents",
-            n=3, as_of_day=state.day
+            n=3, as_of_time=system_time_iso
         )
         agent = Agent(
             role="CEO",
@@ -836,4 +847,3 @@ class DayPlannerOrchestrator:
             e.facts for e in mem.get_event_log()
             if e.type == "day_summary" and e.day >= max(1, day - 7)
         ]
-

--- a/src/flow.py
+++ b/src/flow.py
@@ -34,6 +34,7 @@ from langchain_ollama import OllamaLLM
 
 from memory import Memory, SimEvent
 from graph_dynamics import GraphDynamics
+from sim_clock import SimClock
 from org_lifecycle import (
          OrgLifecycleManager,
          patch_validator_for_lifecycle,
@@ -117,12 +118,13 @@ def build_llm(model_key: str):
 
     if _PROVIDER == "bedrock":
         try:
-            from langchain_aws import ChatBedrock
+            from crewai import LLM
             region = _PRESET.get("aws_region", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
-            llm = ChatBedrock(
-                model_id=model,
+            llm = LLM(
+                model=model,
                 region_name=region,
-                model_kwargs={"max_tokens": 4096, "temperature": 0.7},
+                max_tokens=4096,
+                temperature=0.7,
             )
             logger.info(f"[config] {model_key} → Bedrock/{model} (region={region})")
             return llm
@@ -265,6 +267,7 @@ class State(BaseModel):
     sprint: SprintState = Field(default_factory=SprintState)
     daily_theme: str = ""
     persona_stress: Dict[str, int] = {}
+    actor_cursors: Dict[str, Any] = Field(default_factory=dict)
 
     # Daily counters — reset each morning, read at end of day
     daily_incidents_opened:   int = 0
@@ -325,7 +328,7 @@ class GitSimulator:
         self._mem = mem
         self._graph = social_graph
 
-    def create_pr(self, author: str, ticket_id: str, title: str, reviewers: Optional[List[str]] = None) -> Dict:
+    def create_pr(self, author: str, ticket_id: str, title: str,timestamp: str, reviewers: Optional[List[str]] = None) -> Dict:
         pr_id = f"PR-{len(self._state.pr_registry) + 100}"
         
         if not reviewers:
@@ -345,7 +348,7 @@ class GitSimulator:
             "pr_id": pr_id, "ticket_id": ticket_id, "title": title,
             "author": author, "author_email": email_of(author),
             "reviewers": reviewers, "status": "open", "comments": [],
-            "created_day": self._state.day,
+            "created_at": timestamp,
         }
         path = f"{BASE}/git/prs/{pr_id}.json"
         save_json(path, pr)
@@ -353,6 +356,7 @@ class GitSimulator:
         self._mem.embed_artifact(
             id=pr_id, type="pr", title=title, content=json.dumps(pr),
             day=self._state.day, date=str(self._state.current_date.date()),
+            timestamp=timestamp,
             metadata={"author": author, "ticket_id": ticket_id},
         )
         self._state.daily_artifacts_created += 1
@@ -427,10 +431,12 @@ class Flow(Flow[State]):
         self.social_graph   = self.graph_dynamics.G
         self._git = GitSimulator(self.state, self._mem, self.social_graph)
         self._day_planner = DayPlannerOrchestrator(CONFIG, WORKER_MODEL, PLANNER_MODEL)
+        self._clock = SimClock(self.state)
         self._normal_day = NormalDayHandler(
             config=CONFIG, mem=self._mem, state=self.state,
             graph_dynamics=self.graph_dynamics, social_graph=self.social_graph,
             git=self._git, worker_llm=WORKER_MODEL, planner_llm=PLANNER_MODEL,
+            clock=self._clock
         )
         self._lifecycle = OrgLifecycleManager(
             config=CONFIG,
@@ -535,8 +541,11 @@ class Flow(Flow[State]):
         tech_task = Task(description=tech_prompt, expected_output=f"{tech_count} full Markdown pages separated by '---PAGE BREAK---'.", agent=historian)
         biz_task  = Task(description=biz_prompt,  expected_output="Two full Markdown pages separated by '---PAGE BREAK---'.", agent=historian)
 
-        crew   = Crew(agents=[historian], tasks=[tech_task, biz_task], verbose=False, llm=PLANNER_MODEL)
+        crew   = Crew(agents=[historian], tasks=[tech_task, biz_task], verbose=False)
         result = str(crew.kickoff())
+
+        from datetime import datetime, time
+        genesis_time = datetime.combine(self.state.current_date.date(), time(8, 0)).isoformat()
 
         for raw in result.split("---PAGE BREAK---"):
             ids = re.findall(r"CONF-[A-Z]+-\d+", raw)
@@ -555,8 +564,11 @@ class Flow(Flow[State]):
                 day=self.state.day, date=str(self.state.current_date.date()),
                 metadata={"authors": str(eng_members)},
             )
+
+            
             self._mem.log_event(SimEvent(
-                type="confluence_created", day=self.state.day, date=str(self.state.current_date.date()),
+                type="confluence_created", timestamp=genesis_time,
+                day=self.state.day, date=str(self.state.current_date.date()),
                 actors=eng_members, artifact_ids={"confluence": doc_id},
                 facts={"title": title, "phase": "genesis"},
                 summary=f"Archive page {doc_id} created: {title}", tags=["genesis", "confluence"],
@@ -574,9 +586,10 @@ class Flow(Flow[State]):
                 self.state.current_date += timedelta(days=1)
                 continue
 
+            self._clock.reset_to_business_start(ALL_NAMES)
             date_str = str(self.state.current_date.date())
-            departures = self._lifecycle.process_departures(self.state.day, date_str, self.state)
-            hires      = self._lifecycle.process_hires(self.state.day, date_str, self.state)
+            departures = self._lifecycle.process_departures(self.state.day, date_str, self.state, self._clock)
+            hires      = self._lifecycle.process_hires(self.state.day, date_str, self.state, self._clock)
 
             if departures or hires:
                 # Patch the day planner's validator to reflect the new roster
@@ -585,6 +598,7 @@ class Flow(Flow[State]):
             org_plan = self._day_planner.plan(
                 self.state, self._mem, self.graph_dynamics,
                 lifecycle_context=self._lifecycle.get_roster_context(),
+                clock=self._clock
             )
             self.state.daily_theme  = org_plan.org_theme
             self.state.org_day_plan = org_plan
@@ -620,6 +634,9 @@ class Flow(Flow[State]):
         raw_themes = CONFIG.get("sprint_ticket_themes", ["Refactor legacy system", "Add retry logic", "Fix errors", "QA regression"])
         ticket_themes = [render_template(t) for t in raw_themes]
         n_tickets = CONFIG["simulation"].get("sprint_tickets_per_planning", 4)
+
+        meeting_time = self._clock.schedule_meeting(attendees, min_hour=9, max_hour=11)
+        timestamp_str = meeting_time.isoformat()
         
         new_tickets = []
         for theme in random.sample(ticket_themes, min(n_tickets, len(ticket_themes))):
@@ -629,6 +646,8 @@ class Flow(Flow[State]):
             ticket = {
                 "id": tid, "title": theme, "status": "To Do", "assignee": assignee,
                 "sprint": self.state.sprint.sprint_number, "story_points": pts, "linked_prs": [],
+                "created_at": timestamp_str,
+                "updated_at": timestamp_str
             }
             self.state.jira_tickets.append(ticket)
             self.state.sprint.tickets_in_sprint.append(tid)
@@ -642,8 +661,9 @@ class Flow(Flow[State]):
             "total_points": sum(t["story_points"] for t in new_tickets),
             "sprint_goal": render_template(CONFIG.get("sprint_goal_template", "Stabilize {legacy_system} and deliver sprint features")),
         }
+
         self._mem.log_event(SimEvent(
-            type="sprint_planned", day=self.state.day, date=str(self.state.current_date.date()),
+            type="sprint_planned", day=self.state.day, date=str(self.state.current_date.date()), timestamp=timestamp_str,
             actors=attendees, artifact_ids={"jira_tickets": json.dumps([t["id"] for t in new_tickets])},
             facts=sprint_facts, summary=f"Sprint #{sprint_facts['sprint_number']} planned.", tags=["sprint", "planning"],
         ))
@@ -657,7 +677,13 @@ class Flow(Flow[State]):
     def _handle_standup(self):
         logger.info(f"  [bold blue]☕ Standup[/bold blue]")
         attendees = random.sample(ALL_NAMES, min(8, len(ALL_NAMES)))
-        ctx = self._mem.context_for_prompt("current sprint active tickets and incidents", n=4, as_of_day=self.state.day)
+        meeting_time = self._clock.schedule_meeting(attendees, min_hour=9, max_hour=10, duration_mins=15)
+        meeting_time_iso = meeting_time.isoformat()
+        ctx = self._mem.context_for_prompt(
+            "current sprint active tickets and incidents", 
+            n=4, 
+            as_of_time=meeting_time_iso
+        )
         
         profiles = []
         for name in attendees:
@@ -686,7 +712,9 @@ class Flow(Flow[State]):
         slack_path = f"{BASE}/slack/channels/standup/{date_str}.json"
         save_json(slack_path, messages)
         self.state.slack_threads.append({"date": date_str, "channel": "standup", "message_count": len(messages)})
-        self._mem.log_event(SimEvent(type="standup", day=self.state.day, date=date_str, actors=[m["user"] for m in messages], artifact_ids={"slack": slack_path}, facts={"attendee_count": len(messages)}, summary=f"Standup: {len(messages)} attendees shared updates.", tags=["standup"]))
+        self._mem.log_event(SimEvent(type="standup", timestamp=meeting_time_iso, day=self.state.day, date=date_str, actors=[m["user"] for m in messages], 
+                                     artifact_ids={"slack": slack_path}, facts={"attendee_count": len(messages)}, 
+                                     summary=f"Standup: {len(messages)} attendees shared updates.", tags=["standup"]))
 
         self._record_daily_actor(*[m["user"] for m in messages])
         self._record_daily_event("standup")
@@ -695,7 +723,11 @@ class Flow(Flow[State]):
     def _handle_retrospective(self):
         logger.info(f"  [bold blue]🔄 Retro — Sprint #{self.state.sprint.sprint_number}[/bold blue]")
         conf_id = next_conf_id(self.state, "RETRO")
-        ctx = self._mem.context_for_prompt(f"sprint {self.state.sprint.sprint_number} incidents velocity", n=4, as_of_day=self.state.day)
+
+        attendees = ALL_NAMES
+        meeting_time = self._clock.schedule_meeting(attendees, min_hour=14, max_hour=16, duration_mins=60)
+        meeting_time_iso = meeting_time.isoformat()
+        ctx = self._mem.context_for_prompt(f"sprint {self.state.sprint.sprint_number} incidents velocity", n=4, as_of_time=meeting_time_iso)
         scrum_master = resolve_role("scrum_master")
         historian = Agent(role="Scrum Master", goal="Write retro.", backstory=persona_backstory(scrum_master, self._mem, graph_dynamics=self.graph_dynamics), llm=PLANNER_MODEL)
         task = Task(description=f"Write retro Confluence {conf_id} for Sprint #{self.state.sprint.sprint_number}.\nContext:\n{ctx}\nSections: What went well, What didn't, Action items.", expected_output="Markdown.", agent=historian)
@@ -705,7 +737,9 @@ class Flow(Flow[State]):
         entry = {"id": conf_id, "title": f"Retro Sprint #{self.state.sprint.sprint_number}", "summary": "Sprint Retrospective", "path": path}
         self.state.confluence_pages.append(entry)
         self._embed_and_count(id=conf_id, type="confluence", title=entry["title"], content=content, day=self.state.day, date=str(self.state.current_date.date()))
-        self._mem.log_event(SimEvent(type="retrospective", day=self.state.day, date=str(self.state.current_date.date()), actors=list(LEADS.values()), artifact_ids={"confluence": conf_id}, facts={"sprint_number": self.state.sprint.sprint_number}, summary=f"Sprint #{self.state.sprint.sprint_number} retrospective.", tags=["retrospective", "sprint"]))
+        self._mem.log_event(SimEvent(type="retrospective", timestamp=meeting_time_iso, day=self.state.day, date=str(self.state.current_date.date()), 
+                            actors=list(LEADS.values()), artifact_ids={"confluence": conf_id}, facts={"sprint_number": self.state.sprint.sprint_number}, 
+                            summary=f"Sprint #{self.state.sprint.sprint_number} retrospective.", tags=["retrospective", "sprint"]))
         self.state.sprint.sprint_number += 1
         self.state.sprint.tickets_in_sprint = []
 
@@ -720,6 +754,10 @@ class Flow(Flow[State]):
         incident_lead = resolve_role("incident_commander")
         eng_peer      = next((n for n in ORG_CHART.get(CONFIG["roles"].get("on_call_engineer", ""), []) if n != on_call), on_call)
 
+        incident_start = self._clock.tick_system(min_mins=30, max_mins=240)
+        incident_start_iso = incident_start.isoformat()
+
+        self._clock.sync_to_system([on_call])
 
         rc_agent = Agent(role="Senior Engineer", goal="Diagnose root cause.", backstory=persona_backstory(on_call, self._mem, graph_dynamics=self.graph_dynamics), llm=PLANNER_MODEL)
         rc_task  = Task(description=f"Theme: {self.state.daily_theme}\nWrite ONE specific technical root cause (max 20 words).", expected_output="One sentence.", agent=rc_agent)
@@ -737,13 +775,15 @@ class Flow(Flow[State]):
             day=self.state.day,
             date_str=str(self.state.current_date.date()),
             state=self.state,
+            timestamp=incident_start_iso
         )
 
         title  = f"{LEGACY['name']}: {self.state.daily_theme[:60]}"
         ticket = {"id": ticket_id, "title": title, "status": "In Progress", "assignee": on_call, "root_cause": root_cause, "linked_prs": []}
         self.state.jira_tickets.append(ticket)
         save_json(f"{BASE}/jira/{ticket_id}.json", ticket)
-        self._embed_and_count(id=ticket_id, type="jira", title=title, content=json.dumps(ticket), day=self.state.day, date=str(self.state.current_date.date()))
+        self._embed_and_count(id=ticket_id, type="jira", title=title, content=json.dumps(ticket), day=self.state.day, 
+                              date=str(self.state.current_date.date()), timestamp=incident_start_iso)
 
         inc = ActiveIncident(ticket_id=ticket_id, title=title, day_started=self.state.day, involves_gap_knowledge=involves_gap, root_cause=root_cause)
         self.state.active_incidents.append(inc)
@@ -753,12 +793,14 @@ class Flow(Flow[State]):
         self._emit_bot_message(
             "system-alerts", 
             "Datadog", 
-            f"🚨 [CRITICAL] Anomaly detected: {root_cause[:40]}... Error rate spiked 400%. System health dropped to {self.state.system_health}."
+            f"🚨 [CRITICAL] Anomaly detected: {root_cause[:40]}... Error rate spiked 400%. System health dropped to {self.state.system_health}.",
+            incident_start_iso
         )
         self._emit_bot_message(
             "incidents", 
             "PagerDuty", 
-            f"📞 Paging on-call engineer: {on_call}. Incident linked to [{ticket_id}]."
+            f"📞 Paging on-call engineer: {on_call}. Incident linked to [{ticket_id}].",
+            incident_start_iso
         )
         self.state.system_health = max(0, self.state.system_health - 15)
 
@@ -771,7 +813,8 @@ class Flow(Flow[State]):
             self._handle_external_contact(inc, contact)
 
         self._mem.log_event(SimEvent(
-            type="incident_opened", day=self.state.day, date=str(self.state.current_date.date()),
+            type="incident_opened", timestamp=incident_start_iso,
+            day=self.state.day, date=str(self.state.current_date.date()),
             actors=[on_call, incident_lead],
             artifact_ids={"jira": ticket_id},
             facts={"title": title, "root_cause": root_cause, "involves_gap": involves_gap},
@@ -790,7 +833,9 @@ class Flow(Flow[State]):
             domain_keywords=gap_kw if involves_gap else None,
         )
         self._mem.log_event(SimEvent(
-            type="escalation_chain", day=self.state.day,
+            type="escalation_chain", 
+            timestamp=incident_start_iso,
+            day=self.state.day,
             date=str(self.state.current_date.date()),
             actors=[n for n, _ in chain.chain],
             artifact_ids={"jira": ticket_id},
@@ -808,7 +853,9 @@ class Flow(Flow[State]):
                 if k.lower() in self.state.daily_theme.lower()
             ]
             self._mem.log_event(SimEvent(
-                type="knowledge_gap_detected", day=self.state.day, date=str(self.state.current_date.date()),
+                type="knowledge_gap_detected", 
+                timestamp=incident_start_iso,
+                day=self.state.day, date=str(self.state.current_date.date()),
                 actors=[on_call, eng_peer],
                 artifact_ids={"jira": ticket_id},
                 facts={"gap_area": gap_areas or [LEGACY["name"]], "involves_gap": True},
@@ -821,11 +868,20 @@ class Flow(Flow[State]):
                            if "eng" in k.lower()), None)
            if eng_key:
                eng_dept_plan = self.state.org_day_plan.dept_plans[eng_key]
+
+               # 1. Primary rolls their independent time (2.0 to 5.5 hours)
+               primary_hrs_lost = round(random.uniform(2.0, 5.5), 1)
+               
+               # 2. Peer rolls a DEPENDENT time (e.g., 20% to 60% of the primary's time)
+               # This guarantees the peer never works longer than the primary.
+               peer_fraction = random.uniform(0.2, 0.6)
+               peer_hrs_lost = round(primary_hrs_lost * peer_fraction, 1)
+
                for ep in eng_dept_plan.engineer_plans:
                    if ep.name in [on_call, incident_lead]:
-                       ep.apply_incident_pressure(inc.title, hrs_lost=3.5)
+                       ep.apply_incident_pressure(inc.title, hrs_lost=primary_hrs_lost)
                    elif ep.name == eng_peer:
-                       ep.apply_incident_pressure(inc.title, hrs_lost=1.5)
+                       ep.apply_incident_pressure(inc.title, hrs_lost=peer_hrs_lost)
 
         logger.info(f"    [red]🚨 {ticket_id}:[/red] {root_cause[:65]}")
 
@@ -834,6 +890,8 @@ class Flow(Flow[State]):
         on_call  = resolve_role("on_call_engineer")
         eng_peer = next((n for n in ORG_CHART.get(CONFIG["roles"].get("on_call_engineer", ""), []) if n != on_call), on_call)
 
+        cron_time_iso = self._clock.now("system").isoformat()
+
         for inc in self.state.active_incidents:
             if inc.stage == "detected":
                 inc.stage = "investigating"
@@ -841,11 +899,13 @@ class Flow(Flow[State]):
 
             elif inc.stage == "investigating":
                 inc.stage = "fix_in_progress"
-                pr = self._git.create_pr(author=on_call, ticket_id=inc.ticket_id, title=f"[{inc.ticket_id}] Fix: {inc.root_cause[:60]}")
+                pr = self._git.create_pr(author=on_call, ticket_id=inc.ticket_id, title=f"[{inc.ticket_id}] Fix: {inc.root_cause[:60]}",
+                                          timestamp=cron_time_iso)
                 self._emit_bot_message(
                     "engineering",
                     "GitHub",
-                    f"🛠️ {on_call} opened PR {pr['pr_id']}: [{inc.ticket_id}] Fix. Reviewers requested: {', '.join(pr['reviewers'])}."
+                    f"🛠️ {on_call} opened PR {pr['pr_id']}: [{inc.ticket_id}] Fix. Reviewers requested: {', '.join(pr['reviewers'])}.",
+                    cron_time_iso
                 )
                 inc.pr_id = pr["pr_id"]
                 logger.info(f"    [yellow]🔧 {inc.ticket_id}:[/yellow] {pr['pr_id']} opened.")
@@ -868,14 +928,16 @@ class Flow(Flow[State]):
                 self._emit_bot_message(
                     "engineering",
                     "GitHub Actions",
-                    f"✅ Build passed for PR {inc.pr_id}. Deploying to production..."
+                    f"✅ Build passed for PR {inc.pr_id}. Deploying to production...",
+                    cron_time_iso
                 )
                 self.state.system_health = min(100, self.state.system_health + 20)
                 self._write_postmortem(inc)
                 self.state.resolved_incidents.append(inc.ticket_id)
                 self.state.daily_incidents_resolved += 1
                 self._mem.log_event(SimEvent(
-                    type="incident_resolved", day=self.state.day, date=str(self.state.current_date.date()),
+                    type="incident_resolved", timestamp=cron_time_iso,
+                    day=self.state.day, date=str(self.state.current_date.date()),
                     actors=[on_call, eng_peer], artifact_ids={"jira": inc.ticket_id, "pr": inc.pr_id or ""},
                     facts={"root_cause": inc.root_cause, "duration_days": inc.days_active},
                     summary=f"{inc.ticket_id} resolved in {inc.days_active}d.", tags=["incident_resolved"]
@@ -893,6 +955,11 @@ class Flow(Flow[State]):
         on_call  = resolve_role("postmortem_writer")
         eng_peer = next((n for n in ORG_CHART.get(CONFIG["roles"].get("postmortem_writer", ""), []) if n != on_call), on_call)
         conf_id  = next_conf_id(self.state, "ENG")
+
+        pm_duration_hours = random.randint(60, 180) / 60.0
+        artifact_time, new_cursor = self._clock.advance_actor(on_call, hours=pm_duration_hours)
+        artifact_time_iso = artifact_time.isoformat()
+
         writer   = Agent(role="Senior Engineer", goal="Write a postmortem.", backstory=persona_backstory(on_call, self._mem, graph_dynamics=self.graph_dynamics), llm=PLANNER_MODEL)
         task = Task(
             description=f"Write Confluence postmortem for {inc.ticket_id}.\nActual Root Cause: {inc.root_cause}\nDuration: {inc.days_active} days.\nFormat as Markdown.",
@@ -904,16 +971,19 @@ class Flow(Flow[State]):
         save_md(path, full_content)
         entry = {"id": conf_id, "title": f"Postmortem: {inc.ticket_id}", "path": path}
         self.state.confluence_pages.append(entry)
-        self._embed_and_count(id=conf_id, type="confluence", title=entry["title"], content=full_content, day=self.state.day, date=str(self.state.current_date.date()))
+        self._embed_and_count(id=conf_id, type="confluence", title=entry["title"], content=full_content, day=self.state.day, date=str(self.state.current_date.date()),
+                               timestamp=artifact_time_iso)
         self._mem.log_event(SimEvent(
-            type="postmortem_created", day=self.state.day, date=str(self.state.current_date.date()),
+            type="postmortem_created", 
+            timestamp=artifact_time_iso,
+            day=self.state.day, date=str(self.state.current_date.date()),
             actors=[on_call, eng_peer],
             artifact_ids={"confluence": conf_id, "jira": inc.ticket_id}, facts={"root_cause": inc.root_cause},
             summary=f"Postmortem {conf_id} written for {inc.ticket_id}.", tags=["postmortem"]
         ))
         logger.info(f"    [green]📄 Postmortem Generated:[/green] {conf_id}")
 
-    def _emit_bot_message(self, channel: str, bot_name: str, text: str):
+    def _emit_bot_message(self, channel: str, bot_name: str, text: str, timestamp: str):
         """Injects a contextual bot message into a specific Slack channel."""
         date_str = str(self.state.current_date.date())
         slack_path = f"{BASE}/slack/channels/{channel}/{date_str}_bots.json"
@@ -928,10 +998,7 @@ class Flow(Flow[State]):
             "user": bot_name, 
             "email": f"{bot_name.lower()}@bot.{COMPANY_DOMAIN}",
             "text": text, 
-            "ts": self.state.current_date.replace(
-                hour=random.randint(8, 17), 
-                minute=random.randint(0, 59)
-            ).isoformat(),
+            "ts": timestamp,
             "is_bot": True
         })
         
@@ -943,7 +1010,11 @@ class Flow(Flow[State]):
         prefix, title = random.choice(rendered)
         conf_id = next_conf_id(self.state, prefix)
         author  = random.choice(ALL_NAMES)
-        ctx     = self._mem.context_for_prompt(title, n=3, as_of_day=self.state.day)
+        session_mins = random.randint(30, 90)
+        session_hours = session_mins / 60.0
+        artifact_time, new_cursor = self._clock.advance_actor(author, hours=session_hours)
+        artifact_time_iso = artifact_time.isoformat()
+        ctx     = self._mem.context_for_prompt(title, n=3, as_of_time=artifact_time_iso)
         
         writer = Agent(role="Corporate Writer", goal="Write documentation.", backstory=f"You are {author}.", llm=PLANNER_MODEL)
         task = Task(description=f"Write Confluence page titled '{title}'.\nContext:\n{ctx}\nFormat as Markdown.", expected_output="Markdown.", agent=writer)
@@ -957,6 +1028,7 @@ class Flow(Flow[State]):
             day=self.state.day,
             date_str=str(self.state.current_date.date()),
             state=self.state,
+            timestamp=artifact_time_iso
         )
         
         path = f"{BASE}/confluence/general/{conf_id}.md"
@@ -964,7 +1036,9 @@ class Flow(Flow[State]):
         entry = {"id": conf_id, "title": title, "path": path}
         self.state.confluence_pages.append(entry)
         self._embed_and_count(id=conf_id, type="confluence", title=title, content=full_content, day=self.state.day, date=str(self.state.current_date.date()))
-        self._mem.log_event(SimEvent(type="confluence_created", day=self.state.day, date=str(self.state.current_date.date()), actors=[author], artifact_ids={"confluence": conf_id}, facts={"title": title}, summary=f"{author} created {conf_id}.", tags=["confluence"]))
+        self._mem.log_event(SimEvent(type="confluence_created", timestamp=artifact_time_iso,
+                                     day=self.state.day, date=str(self.state.current_date.date()), 
+                                     actors=[author], artifact_ids={"confluence": conf_id}, facts={"title": title}, summary=f"{author} created {conf_id}.", tags=["confluence"]))
         logger.info(f"    [dim]📝 Generated Confluence Page: {conf_id} — {title}[/dim]")
 
     # ─── END OF DAY ───────────────────────────
@@ -979,9 +1053,17 @@ class Flow(Flow[State]):
 
         self.state.morale_history.append(self.state.team_morale)
 
+        all_cursors = [self._clock.now(a) for a in ALL_NAMES]
+        latest_time_worked = max(all_cursors) if all_cursors else self.state.current_date
+
+        # Ensure the summary doesn't happen before 17:30
+        eod_baseline = self.state.current_date.replace(hour=17, minute=30, second=0)
+        summary_time = max(latest_time_worked, eod_baseline)
+        housekeeping_time = summary_time + timedelta(minutes=1)
+
         # ── end_of_day event (unchanged) ─────────────────────────────────────────
         self._mem.log_event(SimEvent(
-            type="end_of_day", day=self.state.day, date=date_str, actors=[], artifact_ids={},
+            type="end_of_day", timestamp=housekeeping_time.isoformat(), day=self.state.day, date=date_str, actors=[], artifact_ids={},
             facts={"morale": self.state.team_morale, "system_health": self.state.system_health},
             summary=f"Day {self.state.day} end.", tags=["eod"]
         ))
@@ -1014,6 +1096,7 @@ class Flow(Flow[State]):
         # ── Enriched day_summary SimEvent ────────────────────────────────────────
         self._mem.log_event(SimEvent(
             type="day_summary",
+            timestamp=housekeeping_time.isoformat(),
             day=self.state.day,
             date=date_str,
             actors=unique_actors,                          # populated — was always []
@@ -1087,6 +1170,7 @@ class Flow(Flow[State]):
                 )
                 self._mem.log_event(SimEvent(
                     type="escalation_chain",
+                    timestamp=housekeeping_time.isoformat(),
                     day=self.state.day,
                     date=date_str,
                     actors=dept_members[:2],
@@ -1197,6 +1281,13 @@ class Flow(Flow[State]):
         tone         = contact.get("summary_tone", "professional")
         date_str     = str(self.state.current_date.date())
 
+        participants = [liaison_name, display_name]
+        interaction_mins = random.randint(15, 45)
+        interaction_hours = interaction_mins / 60.0
+
+        start_time, end_time = self._clock.sync_and_advance(participants, hours=interaction_hours)
+        interaction_start_iso = start_time.isoformat()
+
         # Boost the edge between liaison and external node — they just talked
         external_node = contact["name"]
         if self.social_graph.has_edge(liaison_name, external_node):
@@ -1205,7 +1296,7 @@ class Flow(Flow[State]):
             )
 
         # Generate the Slack summary message
-        ctx = self._mem.context_for_prompt(inc.root_cause, n=2, as_of_day=self.state.day)
+        ctx = self._mem.context_for_prompt(inc.root_cause, n=2, as_of_time=interaction_start_iso)
 
         agent = Agent(
             role="Employee",
@@ -1262,6 +1353,7 @@ class Flow(Flow[State]):
         # SimEvent — this is what makes it retrievable as ground truth
         self._mem.log_event(SimEvent(
             type="external_contact_summarized",
+            timestamp=interaction_start_iso,
             day=self.state.day,
             date=date_str,
             actors=[liaison_name, external_node],

--- a/src/memory.py
+++ b/src/memory.py
@@ -50,6 +50,7 @@ class SimEvent:
     type: str
     day: int
     date: str
+    timestamp: str
     actors: List[str]
     artifact_ids: Dict[str, str]
     facts: Dict[str, Any]
@@ -75,6 +76,7 @@ class SimEvent:
             type=d.get("type", ""),
             day=d.get("day", 0),
             date=d.get("date", ""),
+            timestamp=d.get("timestamp", ""),
             actors=d.get("actors", []),
             artifact_ids=d.get("artifact_ids", {}),
             facts=d.get("facts", {}),
@@ -279,7 +281,7 @@ class Memory:
                 },
                 {
                     "type": "filter",
-                    "path": "day"
+                    "path": "timestamp"
                 }
             ]
         }
@@ -312,7 +314,7 @@ class Memory:
 
     # ─── WRITE ────────────────────────────────
 
-    def embed_artifact(self, id: str, type: str, title: str, content: str, day: int, date: str, metadata: Optional[Dict] = None):
+    def embed_artifact(self, id: str, type: str, title: str, content: str, day: int, date: str, timestamp: str, metadata: Optional[Dict] = None):
         """Upsert artifact into MongoDB with vector embedding."""
         embed_text = f"{title}\n\n{content[:2000]}"
         vector = self._embedder.embed(embed_text)
@@ -324,6 +326,7 @@ class Memory:
             "content": content,
             "day": day,
             "date": date,
+            "timestamp": timestamp,
             "embedding": vector,
             "metadata": metadata or {}
         }
@@ -395,31 +398,35 @@ class Memory:
         self,
         query: str,
         n: int = 3,
-        as_of_day: Optional[int] = None,
+        as_of_time: Optional[str] = None
     ) -> List[SimEvent]:
         """
         Returns the n most relevant SimEvents for the query.
         If as_of_day is provided, restricts to events on or before that day.
         """
         query_filter = {}
-        if as_of_day is not None:
-            query_filter["day"] = {"$lte": as_of_day}
+        
+        # Apply the strict chronological cutoff
+        if as_of_time is not None:
+            query_filter["timestamp"] = {"$lte": as_of_time}
 
-        # Assuming recall_events currently does a text/vector search —
-        # add the day filter to whatever query it's already building.
-        # If it's a simple find(), it becomes:
+        # Query MongoDB events collection directly
         results = (
             self._events
             .find(query_filter)
-            .sort("day", -1)
+            .sort("timestamp", -1)  # Sort descending so the most recent events come first
             .limit(n * 3)
         )
 
-        # Re-rank by relevance to query if you have embeddings on events,
-        # otherwise just return the most recent n within the day window
-        # Strip MongoDB-internal fields (_id, embedding) before constructing SimEvent
         _MONGO_FIELDS = {"_id", "embedding"}
-        events = [SimEvent(**{k: v for k, v in e.items() if k not in _MONGO_FIELDS}) for e in results]
+        events = [
+            SimEvent(**{k: v for k, v in e.items() if k not in _MONGO_FIELDS}) 
+            for e in results
+        ]
+        
+        # Note: If you have vector embeddings on SimEvents, you would re-rank them 
+        # by the `query` text here. Otherwise, this just returns the n most recent 
+        # events that occurred before the actor's current cursor.
         return events[:n]
 
     # ─── HELPERS ──────────────────────────────
@@ -438,7 +445,7 @@ class Memory:
         self,
         query: str,
         n: int = 4,
-        as_of_day: Optional[int] = None,
+        as_of_time: Optional[str] = None,
     ) -> str:
         """
         Semantic search over embedded artifacts and events.
@@ -457,15 +464,16 @@ class Memory:
                     "queryVector":  self._embedder.embed(query),
                     "path":         "embedding",
                     "numCandidates": oversample,
-                    "limit":        n if as_of_day is None else oversample,
+                    "limit":        n,
                     "index":        "vector_index",
                 }
             }
         ]
 
-        if as_of_day is not None:
-            pipeline.append({"$match": {"day": {"$lte": as_of_day}}})
-            pipeline.append({"$limit": n})
+        if as_of_time is not None:
+            pipeline[0]["$vectorSearch"]["filter"] = {
+                "timestamp": {"$lte": as_of_time}
+            }
 
         pipeline.append({
             "$project": {
@@ -474,6 +482,7 @@ class Memory:
                 "day":     1,
                 "type":    1,
                 "id":      1,
+                "timestamp": 1,
                 "score":   {"$meta": "vectorSearchScore"},
             }
         })
@@ -491,7 +500,7 @@ class Memory:
                 )
 
         # ── Event search (temporal filter applied here too) ───────────────
-        events = self.recall_events(query, n=3, as_of_day=as_of_day)
+        events = self.recall_events(query, n=3, as_of_time=as_of_time) # <-- Updated parameter
 
         if events:
             lines.append("=== RELEVANT EVENTS ===")

--- a/src/normal_day.py
+++ b/src/normal_day.py
@@ -76,6 +76,7 @@ class NormalDayHandler:
         git,
         worker_llm,
         planner_llm,
+        clock
     ):
         self._config         = config
         self._mem            = mem
@@ -90,6 +91,7 @@ class NormalDayHandler:
         self._company        = config["simulation"]["company_name"]
         self._all_names      = [n for dept in config["org_chart"].values() for n in dept]
         self._org_chart      = config["org_chart"]
+        self._clock = clock
 
     # ─── PUBLIC ENTRY POINT ───────────────────────────────────────────────────
 
@@ -190,6 +192,9 @@ class NormalDayHandler:
 
         if not ticket:
             return [name]
+        
+        artifact_time, new_cursor = self._clock.advance_actor(name, hours=item.estimated_hrs)
+        current_actor_time = artifact_time.isoformat()
 
         # Move ticket to In Progress if it's still To Do
         if ticket.get("status") == "To Do":
@@ -197,8 +202,9 @@ class NormalDayHandler:
             self._save_ticket(ticket)
 
         # Generate a realistic JIRA comment from this engineer
+
         ctx = self._mem.context_for_prompt(
-            f"{ticket['title']} {ticket_id}", n=2, as_of_day=self._state.day
+            f"{ticket['title']} {ticket_id}", n=2, as_of_time=current_actor_time
         )
         tone_hint = self._gd.stress_tone_hint(name)
 
@@ -233,6 +239,7 @@ class NormalDayHandler:
             "text":    comment_text,
             "day":     self._state.day,
         }
+        ticket["updated_at"] = current_actor_time
         ticket.setdefault("comments", []).append(comment)
         self._save_ticket(ticket)
 
@@ -240,19 +247,20 @@ class NormalDayHandler:
         actors = [name]
         blocker_keywords = ["blocked", "waiting", "need", "unclear", "can't", "cannot"]
         if any(kw in comment_text.lower() for kw in blocker_keywords):
-            collaborator = item.collaborator or self._closest_colleague(name)
-            if collaborator:
+            collaborator = next(iter(item.collaborator), None) or self._closest_colleague(name)
+            if collaborator and ticket_id:
                 actors = self._emit_blocker_slack(
                     name, collaborator, ticket_id, ticket["title"],
-                    comment_text, date_str
+                    comment_text, date_str, current_actor_time
                 )
 
         self._mem.log_event(SimEvent(
             type="ticket_progress",
+            timestamp=current_actor_time,
             day=self._state.day,
             date=date_str,
             actors=actors,
-            artifact_ids={"jira": ticket_id},
+            artifact_ids={"jira": ticket_id} if ticket_id else {},
             facts={
                 "ticket_id":    ticket_id,
                 "title":        ticket["title"],
@@ -260,7 +268,7 @@ class NormalDayHandler:
                 "new_status":   ticket["status"],
                 "has_blocker":  any(kw in comment_text.lower() for kw in blocker_keywords),
             },
-            summary=f"{name} progressed [{ticket_id}]: {ticket['title'][:50]}",
+            summary=f"{name} progressed [{ticket_id or 'unknown'}]: {ticket['title'][:50]}",
             tags=["ticket_progress", "jira"],
         ))
 
@@ -288,7 +296,10 @@ class NormalDayHandler:
 
         author   = pr.get("author", reviewer)
         pr_title = pr.get("title", "Unknown PR")
-        ctx      = self._mem.context_for_prompt(pr_title, n=2, as_of_day=self._state.day)
+        artifact_time, new_cursor = self._clock.advance_actor(author, hours=item.estimated_hrs)
+        current_actor_time = artifact_time.isoformat()
+
+        ctx      = self._mem.context_for_prompt(pr_title, n=2, as_of_time=current_actor_time)
 
         # Generate review comment
         agent = Agent(
@@ -319,14 +330,16 @@ class NormalDayHandler:
         self._emit_bot_message(
             "engineering",
             "GitHub",
-            f"💬 {reviewer} reviewed {pr.get('pr_id', pr_id)}: \"{review_text[:120]}\""
+            f"💬 {reviewer} reviewed {pr.get('pr_id', pr_id)}: \"{review_text[:120]}\"",
+            current_actor_time
         )
 
         # Author acknowledges in Slack if the review raises a question
         actors = [reviewer, author]
         if "?" in review_text:
             actors = self._emit_review_reply(
-                author, reviewer, pr.get("pr_id", "PR"), review_text, date_str
+                author, reviewer, pr.get("pr_id", "PR"), review_text, date_str,
+                current_actor_time
             )
 
         # Boost PR review edge
@@ -334,6 +347,7 @@ class NormalDayHandler:
 
         self._mem.log_event(SimEvent(
             type="pr_review",
+            timestamp=current_actor_time,
             day=self._state.day,
             date=date_str,
             actors=actors,
@@ -363,14 +377,21 @@ class NormalDayHandler:
         Generates: DM thread (2-4 messages).
         """
         name         = eng_plan.name
-        collaborator = item.collaborator or self._find_lead_for(name)
+        collaborator = next(iter(item.collaborator), None) or self._find_lead_for(name)
+        participants = [name, collaborator]
         if not collaborator or collaborator == name:
             return [name]
+        
+        meeting_start, meeting_end = self._clock.sync_and_advance(
+            participants, 
+            hours=item.estimated_hrs
+        )
+        meeting_time_iso = meeting_start.isoformat()
 
         stress_a = self._gd.stress_tone_hint(name)
         stress_b = self._gd.stress_tone_hint(collaborator)
         ctx      = self._mem.context_for_prompt(
-            f"1on1 {name} {collaborator} workload", n=2, as_of_day=self._state.day
+            f"1on1 {name} {collaborator} workload", n=2, as_of_time=meeting_time_iso
         )
 
         agent = Agent(
@@ -401,6 +422,18 @@ class NormalDayHandler:
         )
         if not messages:
             return [name, collaborator]
+        
+        from datetime import datetime, timedelta
+        import random
+
+        current_msg_time = datetime.fromisoformat(meeting_time_iso)
+
+        for msg in messages:
+            # Stamp the message with our exact, mathematically safe time
+            msg["ts"] = current_msg_time.isoformat()
+            
+            # Add 1 to 4 random minutes so the reply looks like a human typing
+            current_msg_time += timedelta(minutes=random.randint(1, 4))
 
         p1, p2    = sorted([name, collaborator])
         channel   = f"dm_{p1.lower()}_{p2.lower()}"
@@ -409,6 +442,7 @@ class NormalDayHandler:
 
         self._mem.log_event(SimEvent(
             type="1on1",
+            timestamp=meeting_time_iso,
             day=self._state.day,
             date=date_str,
             actors=[name, collaborator],
@@ -435,7 +469,7 @@ class NormalDayHandler:
         The question is grounded in the engineer's current ticket or blocker.
         """
         asker        = eng_plan.name
-        collaborator = item.collaborator or self._closest_colleague(asker)
+        collaborator = next(iter(item.collaborator), None) or self._closest_colleague(asker)
         ticket_id    = item.related_id
         ticket       = self._find_ticket(ticket_id)
         ticket_title = ticket["title"] if ticket else item.description
@@ -459,7 +493,16 @@ class NormalDayHandler:
         responders.extend(random.sample(extras, min(1, len(extras))))
         all_actors = list({asker} | set(responders))
 
-        ctx = self._mem.context_for_prompt(ticket_title, n=2, as_of_day=self._state.day)
+        chat_duration_mins = random.randint(5, 20)
+        chat_duration_hours = chat_duration_mins / 60.0
+
+        meeting_start, meeting_end = self._clock.sync_and_advance(
+            all_actors, 
+            hours=chat_duration_hours
+        )
+        meeting_time_iso = meeting_start.isoformat()
+
+        ctx = self._mem.context_for_prompt(ticket_title, n=2, as_of_time=meeting_time_iso)
 
         agent = Agent(
             role="Slack Thread Writer",
@@ -493,12 +536,25 @@ class NormalDayHandler:
         messages = self._parse_slack_messages(result, all_actors, hour_range=(10, 16))
         if not messages:
             return all_actors
+        
+        from datetime import datetime, timedelta
+        import random
+
+        current_msg_time = datetime.fromisoformat(meeting_time_iso)
+
+        for msg in messages:
+            # Stamp the message with our exact, mathematically safe time
+            msg["ts"] = current_msg_time.isoformat()
+            
+            # Add 1 to 4 random minutes so the reply looks like a human typing
+            current_msg_time += timedelta(minutes=random.randint(1, 4))
 
         path = f"{self._base}/slack/channels/{channel}/{date_str}_{asker.lower()}_q.json"
         self._save_slack(path, messages, channel)
 
         self._mem.log_event(SimEvent(
             type="async_question",
+            timestamp=meeting_time_iso,
             day=self._state.day,
             date=date_str,
             actors=all_actors,
@@ -530,8 +586,10 @@ class NormalDayHandler:
         Generates: Slack thread + optional Confluence stub.
         """
         initiator = eng_plan.name
-        collaborator = item.collaborator or self._closest_colleague(initiator)
-        participants = list({initiator, collaborator} if collaborator else {initiator})
+        collaborators = item.collaborator or (
+            [c] if (c := self._closest_colleague(initiator)) else []
+        )
+        participants = list({initiator} | set(collaborators))
 
         # Pull one more person with relevant expertise if available
         if len(participants) < 3:
@@ -545,7 +603,16 @@ class NormalDayHandler:
                     participants.append(name)
                     break
 
-        ctx = self._mem.context_for_prompt(item.description, n=3, as_of_day=self._state.day)
+        chat_duration_mins = random.randint(5, 45)
+        chat_duration_hours = chat_duration_mins / 60.0
+
+        meeting_start, meeting_end = self._clock.sync_and_advance(
+            participants, 
+            hours=chat_duration_hours
+        )
+        meeting_time_iso = meeting_start.isoformat()
+
+        ctx = self._mem.context_for_prompt(item.description, n=3, as_of_time=meeting_time_iso)
 
         agent = Agent(
             role="Engineering Team",
@@ -581,6 +648,18 @@ class NormalDayHandler:
             f"{date_str}_{initiator.lower()}_design.json"
         )
         if messages:
+            from datetime import datetime, timedelta
+            import random
+
+            current_msg_time = datetime.fromisoformat(meeting_time_iso)
+
+            for msg in messages:
+                # Stamp the message with our exact, mathematically safe time
+                msg["ts"] = current_msg_time.isoformat()
+                
+                # Add 1 to 4 random minutes so the reply looks like a human typing
+                current_msg_time += timedelta(minutes=random.randint(1, 8))
+
             self._save_slack(path, messages, dept_channel)
 
         # 30% chance a design discussion spawns a Confluence stub
@@ -592,6 +671,7 @@ class NormalDayHandler:
 
         self._mem.log_event(SimEvent(
             type="design_discussion",
+            timestamp=meeting_time_iso,
             day=self._state.day,
             date=date_str,
             actors=participants,
@@ -627,12 +707,22 @@ class NormalDayHandler:
         Generates: DM thread. Boosts social graph edge significantly.
         """
         mentor   = eng_plan.name
-        mentee   = item.collaborator or self._find_junior_colleague(mentor)
+        mentee = next(iter(item.collaborator), None) or self._find_junior_colleague(mentor)
         if not mentee or mentee == mentor:
             return [mentor]
+        
+        participants = [mentor, mentee]
+
+        session_mins = random.randint(30, 90)
+        session_hours = session_mins / 60.0
+        meeting_start, meeting_end = self._clock.sync_and_advance(
+            participants, 
+            hours=session_hours
+        )
+        meeting_time_iso = meeting_start.isoformat()
 
         ctx = self._mem.context_for_prompt(
-            f"mentoring {mentee} learning growth", n=2, as_of_day=self._state.day
+            f"mentoring {mentee} learning growth", n=2, as_of_time=meeting_time_iso
         )
 
         agent = Agent(
@@ -676,6 +766,7 @@ class NormalDayHandler:
 
         self._mem.log_event(SimEvent(
             type="mentoring",
+            timestamp=meeting_time_iso,
             day=self._state.day,
             date=date_str,
             actors=[mentor, mentee],
@@ -700,10 +791,13 @@ class NormalDayHandler:
         name    = eng_plan.name
         channel = dept_of_name(name, self._org_chart).lower().replace(" ", "-")
 
+        cron_time_iso = self._clock.now("system").isoformat()
+
         self._emit_bot_message(
             channel,
             name,
-            f"Working on: {item.description}"
+            f"Working on: {item.description}",
+            cron_time_iso
         )
         return [name]
 
@@ -717,6 +811,7 @@ class NormalDayHandler:
         ticket_title: str,
         blocker_text: str,
         date_str:    str,
+        timestamp: str
     ) -> List[str]:
         """Short 2-message Slack exchange when an engineer is blocked."""
         asker_dept = dept_of_name(asker, self._org_chart)
@@ -744,12 +839,36 @@ class NormalDayHandler:
         )
 
         if messages:
+            from datetime import datetime, timedelta
+            import random
+
+            current_msg_time = datetime.fromisoformat(timestamp)
+
+            for msg in messages:
+                # Stamp the message with our exact, mathematically safe time
+                msg["ts"] = current_msg_time.isoformat()
+                
+                # Add 1 to 4 random minutes so the reply looks like a human typing
+                current_msg_time += timedelta(minutes=random.randint(1, 4))
+
             path = (
                 f"{self._base}/slack/channels/{channel}/"
                 f"{date_str}_{asker.lower()}_blocked.json"
             )
             self._save_slack(path, messages, channel)
             self._gd.record_slack_interaction([asker, collaborator])
+
+            self._mem.log_event(SimEvent(
+                type="blocker_flagged",
+                day=self._state.day,
+                date=date_str,
+                timestamp=timestamp,
+                actors=[asker, collaborator],
+                artifact_ids={"jira": ticket_id},
+                facts={"blocker_reason": blocker_text},
+                summary=f"{asker} is blocked on {ticket_id}, pinged {collaborator}.",
+                tags=["slack", "blocker"]
+            ))
 
         return [asker, collaborator]
 
@@ -760,6 +879,7 @@ class NormalDayHandler:
         pr_id:     str,
         review_text: str,
         date_str:  str,
+        timestamp:   str
     ) -> List[str]:
         """Author replies to a review question in #engineering."""
         agent = Agent(
@@ -783,7 +903,8 @@ class NormalDayHandler:
         self._emit_bot_message(
             "engineering", "GitHub",
             f"💬 {author} replied to {reviewer}'s review on {pr_id}: "
-            f"\"{reply[:100]}\""
+            f"\"{reply[:100]}\"",
+            timestamp
         )
         return [author, reviewer]
 
@@ -797,6 +918,15 @@ class NormalDayHandler:
     ) -> Optional[str]:
         """Creates a brief Confluence stub from a design discussion."""
         conf_id = f"CONF-ENG-{len(self._state.confluence_pages) + 1:03d}"
+
+        artifact_time, new_cursor = self._clock.advance_actor(author, hours=0.5)
+        artifact_time_iso = artifact_time.isoformat()
+
+        safe_ctx = self._mem.context_for_prompt(
+            f"{topic} design discussion", 
+            n=3, 
+            as_of_time=artifact_time_iso
+        )
 
         agent = Agent(
             role="Technical Writer",
@@ -826,10 +956,13 @@ class NormalDayHandler:
         path = f"{self._base}/confluence/design/{conf_id}.md"
         self._save_md(path, full)
 
+        
+
         entry = {"id": conf_id, "title": f"Design: {topic[:50]}", "path": path}
         self._state.confluence_pages.append(entry)
         self._mem.embed_artifact(
             id=conf_id, type="confluence",
+            timestamp=artifact_time_iso,
             title=entry["title"], content=full,
             day=self._state.day, date=date_str,
             metadata={"authors": str(participants), "type": "design_doc"},
@@ -838,6 +971,7 @@ class NormalDayHandler:
 
         self._mem.log_event(SimEvent(
             type="confluence_created",
+            timestamp=artifact_time_iso,
             day=self._state.day, date=date_str,
             actors=participants,
             artifact_ids={"confluence": conf_id},
@@ -855,8 +989,11 @@ class NormalDayHandler:
         self, name: str, item: AgendaItem, date_str: str
     ) -> None:
         """Log a deferred agenda item so the record shows the interruption."""
+        current_time_iso = self._clock.now(name).isoformat()
+
         self._mem.log_event(SimEvent(
             type="agenda_item_deferred",
+            timestamp=current_time_iso,
             day=self._state.day,
             date=date_str,
             actors=[name],
@@ -877,8 +1014,14 @@ class NormalDayHandler:
     def _log_deep_work(
         self, name: str, item: AgendaItem, date_str: str
     ) -> None:
+        
+        # 1. Deep work takes time! Advance their cursor by the estimated hours.
+        # This prevents anyone else from scheduling a 1-on-1 with them during this block.
+        artifact_time, new_cursor = self._clock.advance_actor(name, hours=item.estimated_hrs)
+
         self._mem.log_event(SimEvent(
             type="deep_work_session",
+            timestamp=artifact_time.isoformat(),
             day=self._state.day,
             date=date_str,
             actors=[name],
@@ -891,17 +1034,21 @@ class NormalDayHandler:
     # ─── AMBIENT SIGNALS (unchanged from original) ────────────────────────────
 
     def _maybe_bot_alerts(self) -> None:
+        cron_time_iso = self._clock.now("system").isoformat()
+
         if random.random() < self._config["simulation"].get("aws_alert_prob", 0.4):
             legacy = self._config.get("legacy_system", {})
             self._emit_bot_message(
                 "system-alerts", "AWS Cost Explorer",
                 f"⚠️ Daily budget threshold exceeded. "
-                f"{legacy.get('aws_alert_message', 'Cloud costs remain elevated.')}"
+                f"{legacy.get('aws_alert_message', 'Cloud costs remain elevated.')}",
+                cron_time_iso
             )
         elif random.random() < self._config["simulation"].get("snyk_alert_prob", 0.2):
             self._emit_bot_message(
                 "engineering", "Snyk Security",
-                "🔒 3 new medium-severity vulnerabilities detected in npm dependencies."
+                "🔒 3 new medium-severity vulnerabilities detected in npm dependencies.",
+                cron_time_iso
             )
 
     def _maybe_adhoc_confluence(self) -> None:
@@ -923,9 +1070,21 @@ class NormalDayHandler:
             k=random.randint(2, 4),
         )
         participants = list(set([seed_person] + colleagues))
-        ctx          = self._mem.context_for_prompt(
-            self._state.daily_theme, n=2, as_of_day=self._state.day
+        # 1. Randomize the duration between 5 and 30 minutes
+        #    (Convert to hours because sync_and_advance expects hours)
+        chat_duration_mins = random.randint(5, 30)
+        chat_duration_hours = chat_duration_mins / 60.0
+
+        thread_start, thread_end = self._clock.sync_and_advance(participants, hours=chat_duration_hours)
+        thread_start_iso = thread_start.isoformat()
+
+        # 2. Mathematically restrict the context to the exact moment the chat begins
+        ctx = self._mem.context_for_prompt(
+            self._state.daily_theme, 
+            n=2, 
+            as_of_time=thread_start_iso 
         )
+
         profiles = [f"{n} ({dept_of_name(n, self._org_chart)})" for n in participants]
 
         agent = Agent(
@@ -1008,7 +1167,7 @@ class NormalDayHandler:
         with open(path, "w") as f:
             _json.dump(ticket, f, indent=2)
 
-    def _emit_bot_message(self, channel: str, bot_name: str, text: str) -> None:
+    def _emit_bot_message(self, channel: str, bot_name: str, text: str, timestamp: str) -> None:
         import os
         date_str   = str(self._state.current_date.date())
         slack_path = f"{self._base}/slack/channels/{channel}/{date_str}_bots.json"

--- a/src/org_lifecycle.py
+++ b/src/org_lifecycle.py
@@ -157,12 +157,12 @@ class OrgLifecycleManager:
     # ─── PUBLIC ───────────────────────────────────────────────────────────────
 
     def process_departures(
-        self, day: int, date_str: str, state
+        self, day: int, date_str: str, state, clock
     ) -> List[DepartureRecord]:
         departures: List[DepartureRecord] = []
 
         for dep_cfg in self._scheduled_departures.get(day, []):
-            record = self._execute_departure(dep_cfg, day, date_str, state, scheduled=True)
+            record = self._execute_departure(dep_cfg, day, date_str, state, scheduled=True, clock=clock)
             if record:
                 departures.append(record)
 
@@ -196,7 +196,7 @@ class OrgLifecycleManager:
                         # from personas so we don't hardcode anything here
                     }
                     record = self._execute_departure(
-                        attrition_cfg, day, date_str, state, scheduled=False
+                        attrition_cfg, day, date_str, state, scheduled=False, clock=clock
                     )
                     if record:
                         departures.append(record)
@@ -205,17 +205,17 @@ class OrgLifecycleManager:
         return departures
 
     def process_hires(
-        self, day: int, date_str: str, state
+        self, day: int, date_str: str, state, clock
     ) -> List[HireRecord]:
         hires: List[HireRecord] = []
         for hire_cfg in self._scheduled_hires.get(day, []):
-            record = self._execute_hire(hire_cfg, day, date_str, state)
+            record = self._execute_hire(hire_cfg, day, date_str, state, clock)
             if record:
                 hires.append(record)
         return hires
 
     def scan_for_knowledge_gaps(
-        self, text: str, triggered_by: str, day: int, date_str: str, state
+        self, text: str, triggered_by: str, day: int, date_str: str, state, timestamp: str
     ) -> List[KnowledgeGapEvent]:
         found: List[KnowledgeGapEvent] = []
         text_lower = text.lower()
@@ -235,7 +235,9 @@ class OrgLifecycleManager:
                 self._gap_events.append(gap_event)
                 found.append(gap_event)
                 self._mem.log_event(SimEvent(
-                    type="knowledge_gap_detected", day=day, date=date_str,
+                    type="knowledge_gap_detected", 
+                    timestamp=timestamp,
+                    day=day, date=date_str,
                     actors=[record.name], artifact_ids={"trigger": triggered_by},
                     facts={
                         "departed_employee":    record.name,
@@ -305,7 +307,7 @@ class OrgLifecycleManager:
     # ─── DEPARTURE ENGINE ─────────────────────────────────────────────────────
 
     def _execute_departure(
-        self, dep_cfg: dict, day: int, date_str: str, state, scheduled: bool
+        self, dep_cfg: dict, day: int, date_str: str, state, scheduled: bool, clock
     ) -> Optional[DepartureRecord]:
         name = dep_cfg["name"]
         G    = self._gd.G
@@ -339,20 +341,25 @@ class OrgLifecycleManager:
             centrality_at_departure=departing_centrality,
         )
 
+        departure_time = clock.schedule_meeting([name], min_hour=9, max_hour=9, duration_mins=15)
+        timestamp_iso = departure_time.isoformat()
+
         # Side-effects run in this exact order so each can still reference live graph:
         #   1. Incident handoff   — needs Dijkstra path through departing node
         #   2. JIRA reassignment  — reads ticket assignees from state
         #   3. Remove node        — graph mutation
         #   4. Centrality vacuum  — diff before/after centrality, apply stress
 
-        self._handoff_active_incidents(name, dept_lead, record, day, date_str, state)
-        self._reassign_jira_tickets(name, dept_lead, record, day, date_str, state)
+        self._handoff_active_incidents(name, dept_lead, record, day, date_str, state, timestamp_iso)
+        self._reassign_jira_tickets(name, dept_lead, record, day, date_str, state, timestamp_iso)
 
         G.remove_node(name)
         self._gd._centrality_dirty = True
         self._gd._stress.pop(name, None)
 
-        self._apply_centrality_vacuum(centrality_before, name, day, date_str)
+        
+
+        self._apply_centrality_vacuum(centrality_before, name, day, date_str, timestamp_iso)
 
         # Mutate org-level collections
         if dept in self._org_chart and name in self._org_chart[dept]:
@@ -372,9 +379,12 @@ class OrgLifecycleManager:
         }
 
         self._schedule_backfill(record, day)
+        
+        
 
         self._mem.log_event(SimEvent(
             type="employee_departed", day=day, date=date_str,
+            timestamp=departure_time.isoformat(),
             actors=[name], artifact_ids={},
             facts={
                 "name":                 name,
@@ -412,7 +422,7 @@ class OrgLifecycleManager:
 
     def _handoff_active_incidents(
         self, name: str, dept_lead: str, record: DepartureRecord,
-        day: int, date_str: str, state
+        day: int, date_str: str, state, timestamp_iso
     ) -> None:
         """
         For every active incident whose linked JIRA ticket is assigned to the
@@ -437,7 +447,9 @@ class OrgLifecycleManager:
             record.incident_handoffs.append(inc.ticket_id)
 
             self._mem.log_event(SimEvent(
-                type="escalation_chain", day=day, date=date_str,
+                type="escalation_chain", 
+                timestamp=timestamp_iso,
+                day=day, date=date_str,
                 actors=[name, new_owner], artifact_ids={"jira": inc.ticket_id},
                 facts={
                     "trigger":          "forced_handoff_on_departure",
@@ -464,7 +476,7 @@ class OrgLifecycleManager:
 
     def _reassign_jira_tickets(
         self, name: str, dept_lead: str, record: DepartureRecord,
-        day: int, date_str: str, state
+        day: int, date_str: str, state, timestamp_iso
     ) -> None:
         """
         Reassign all non-Done JIRA tickets owned by the departing engineer.
@@ -492,7 +504,9 @@ class OrgLifecycleManager:
             record.reassigned_tickets.append(ticket["id"])
 
             self._mem.log_event(SimEvent(
-                type="ticket_progress", day=day, date=date_str,
+                type="ticket_progress", 
+                timestamp=timestamp_iso,
+                day=day, date=date_str,
                 actors=[name, dept_lead], artifact_ids={"jira": ticket["id"]},
                 facts={
                     "ticket_id":    ticket["id"],
@@ -524,6 +538,7 @@ class OrgLifecycleManager:
         departed_name:     str,
         day:               int,
         date_str:          str,
+        clock,
     ) -> None:
         """
         After the departed node is removed, force a fresh centrality computation.
@@ -564,6 +579,7 @@ class OrgLifecycleManager:
 
         self._mem.log_event(SimEvent(
             type="knowledge_gap_detected",   # closest existing type for RAG eval
+            timestamp=clock,
             day=day, date=date_str,
             actors=[n for n, _, _ in vacuum_affected],
             artifact_ids={},
@@ -589,7 +605,7 @@ class OrgLifecycleManager:
     # ─── HIRE ENGINE ──────────────────────────────────────────────────────────
 
     def _execute_hire(
-        self, hire_cfg: dict, day: int, date_str: str, state
+        self, hire_cfg: dict, day: int, date_str: str, state, clock
     ) -> Optional[HireRecord]:
         name = hire_cfg["name"]
         dept = hire_cfg.get("dept", list(self._org_chart.keys())[0])
@@ -641,8 +657,15 @@ class OrgLifecycleManager:
             "dept": dept, "expertise": expertise,
         }
 
+        hire_time = clock.schedule_meeting([name], min_hour=9, max_hour=10, duration_mins=30)
+        # Ensure it doesn't roll back before 09:30
+        if hire_time.minute < 30 and hire_time.hour == 9:
+            hire_time = hire_time.replace(minute=random.randint(30, 59))
+
         self._mem.log_event(SimEvent(
-            type="employee_hired", day=day, date=date_str,
+            type="employee_hired", 
+            timestamp=hire_time.isoformat(),
+            day=day, date=date_str,
             actors=[name], artifact_ids={},
             facts={
                 "name": name, "dept": dept, "role": role,

--- a/src/planner_models.py
+++ b/src/planner_models.py
@@ -26,7 +26,7 @@ class AgendaItem:
                                 # "1on1", "async_question", "mentoring", "deep_work"
     description:   str          # human-readable, e.g. "Continue ORG-101 retry logic"
     related_id:    Optional[str] = None   # ticket ID, PR ID, or Confluence ID if applicable
-    collaborator:  Optional[str] = None   # another engineer this touches (drives Slack)
+    collaborator:  List[str] = field(default_factory=list)  # engineers this touches (drives Slack)
     estimated_hrs: float        = 2.0    # rough time weight — used to detect overload
     deferred:      bool         = False  # set True by incident pressure at runtime
     defer_reason:  Optional[str] = None

--- a/src/sim_clock.py
+++ b/src/sim_clock.py
@@ -1,0 +1,261 @@
+"""
+sim_clock.py
+============
+Actor-Local simulation clock for OrgForge.
+
+This clock guarantees perfect forensic timelines by tracking time per-employee. 
+It prevents "Engineer Cloning" (an employee doing two things at the exact same 
+millisecond) and allows true parallel activity across the company.
+
+Two core mechanisms:
+  AMBIENT (advance_actor): 
+      Moves an individual's cursor forward based on the estimated hours of their 
+      AgendaItem task. Other employees are unaffected.
+      
+  CAUSAL (sync_and_tick / tick_message): 
+      Finds the latest cursor among all participating actors, brings everyone up 
+      to that time (simulating asynchronous delay/waiting), and then ticks forward.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    pass   # State imported at runtime to avoid circular imports
+
+# ── Business hours config ─────────────────────────────────────────────────────
+DAY_START_HOUR   = 9
+DAY_START_MINUTE = 0
+DAY_END_HOUR     = 17
+DAY_END_MINUTE   = 30
+
+# ── Per-cadence reply spacing (minutes) ──────────────────────────────────────
+CADENCE_RANGES = {
+    "incident": (1, 4),    # urgent — tight back-and-forth
+    "normal":   (3, 12),   # standard conversation pace
+    "async":    (10, 35),  # heads-down work, slow replies
+}
+
+
+class SimClock:
+    """
+    Manages time cursors for every actor in the simulation. 
+    Guarantees no overlapping tasks for individuals while allowing the org to run in parallel.
+    """
+
+    def __init__(self, state):
+        self._state = state
+        if not hasattr(self._state, "actor_cursors"):
+            self._state.actor_cursors = {}
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def reset_to_business_start(self, all_actors: List[str]) -> None:
+        """
+        Call at the top of each day in daily_cycle().
+        Resets every actor's cursor to 09:00 on the current simulation date,
+        skipping weekends automatically.
+        """
+        base = self._get_default_start()
+        
+        # Reset all human actors
+        self._state.actor_cursors = {a: base for a in all_actors}
+        
+        # Reset a dedicated system cursor for independent bot alerts
+        self._state.actor_cursors["system"] = base
+
+    def advance_actor(self, actor: str, hours: float) -> tuple[datetime, datetime]:
+        """
+        AMBIENT WORK: Advance an actor's horizon.
+        Returns (artifact_timestamp, new_cursor_horizon).
+        artifact_timestamp is randomly sampled from within the work block.
+        """
+        current = self._get_cursor(actor)
+        delta = timedelta(hours=hours)
+        end_time = self._enforce_business_hours(current + delta)
+        
+        # Sample a random time within the block for the actual JIRA/Confluence timestamp
+        total_seconds = int((end_time - current).total_seconds())
+        if total_seconds > 0:
+            random_offset = random.randint(0, total_seconds)
+            artifact_time = current + timedelta(seconds=random_offset)
+        else:
+            artifact_time = current
+
+        self._set_cursor(actor, end_time)
+        return artifact_time, end_time
+
+    def sync_and_tick(
+        self,
+        actors: List[str],
+        min_mins: int = 5,
+        max_mins: int = 15,
+        allow_after_hours: bool = False,
+    ) -> datetime:
+        """
+        CAUSAL WORK: Synchronizes multiple actors, then ticks forward.
+        Finds the latest time among participants (meaning the thread cannot 
+        start until the busiest person is free), moves everyone to that time, 
+        and advances by a random delta.
+        """
+        # 1. Sync everyone to the maximum cursor
+        synced_time = self._sync_time(actors)
+        
+        # 2. Tick forward from the synced time
+        delta = timedelta(minutes=random.randint(min_mins, max_mins))
+        candidate = synced_time + delta
+
+        if not allow_after_hours:
+            candidate = self._enforce_business_hours(candidate)
+
+        # 3. Update all participants
+        for a in actors:
+            self._set_cursor(a, candidate)
+            
+        return candidate
+
+    def tick_message(
+        self,
+        actors: List[str],
+        cadence: str = "normal",
+        allow_after_hours: bool = False,
+    ) -> datetime:
+        """
+        CAUSAL WORK: Advance sim_time for a specific group of actors by a 
+        cadence-appropriate amount. Use inside _parse_slack_messages().
+        """
+        min_mins, max_mins = CADENCE_RANGES.get(cadence, CADENCE_RANGES["normal"])
+        return self.sync_and_tick(actors, min_mins, max_mins, allow_after_hours)
+    
+    def tick_system(self, min_mins: int = 2, max_mins: int = 5) -> datetime:
+        """Advances the independent system clock for automated bot alerts."""
+        current = self._get_cursor("system")
+        candidate = current + timedelta(minutes=random.randint(min_mins, max_mins))
+        candidate = self._enforce_business_hours(candidate)
+        self._set_cursor("system", candidate)
+        return candidate
+
+    def at(self, actors: List[str], hour: int, minute: int, duration_mins: int = 30) -> datetime:
+        """
+        Pins a scheduled meeting to a specific time. 
+        Returns the exact meeting start time for artifact stamping.
+        """
+        meeting_start = self._get_default_start().replace(hour=hour, minute=minute)
+        meeting_end = meeting_start + timedelta(minutes=duration_mins)
+        
+        for a in actors:
+            # Only advance people who are behind the meeting's end time.
+            # If someone is already past it, they "missed" it, but we don't time-travel them back.
+            if self._get_cursor(a) < meeting_end:
+                self._set_cursor(a, meeting_end)
+                
+        # The artifact itself is stamped exactly when scheduled
+        return meeting_start
+
+    def now(self, actor: str) -> datetime:
+        """Return a specific actor's current time without advancing it."""
+        return self._get_cursor(actor)
+    
+    def sync_to_system(self, actors: List[str]) -> datetime:
+        """
+        INCIDENT RESPONSE: Forces specific actors to jump to the current system 
+        clock (e.g., when an incident fires).
+        """
+        sys_time = self._get_cursor("system")
+        for a in actors:
+            # If they are behind the system alert, pull them forward to it.
+            # If they are somehow ahead, the incident interrupts their future task.
+            if self._get_cursor(a) < sys_time:
+                self._set_cursor(a, sys_time)
+        return sys_time
+    
+    def schedule_meeting(self, actors: List[str], min_hour: int, max_hour: int, duration_mins: int = 45) -> datetime:
+        """
+        Schedules a ceremony within a specific window and syncs all participants to it.
+        Example: schedule_meeting(leads, 9, 11) for Sprint Planning.
+        """
+        # Pick a random top-of-the-hour or half-hour slot in the window
+        hour = random.randint(min_hour, max_hour - 1)
+        minute = random.choice([0, 15, 30, 45])
+        
+        # Use the at() method we defined earlier to pin the actors
+        return self.at(actors, hour, minute, duration_mins)
+    
+    def sync_and_advance(self, actors: List[str], hours: float) -> tuple[datetime, datetime]:
+        """
+        Synchronizes multiple actors to the latest available cursor, 
+        then advances all of them by the specified hours.
+        Returns (meeting_start_time, new_cursor_horizon).
+        """
+        # 1. Find the latest time among all participants
+        start_time = self._sync_time(actors)
+        
+        # 2. Calculate the end time based on the agenda item's duration
+        delta = timedelta(hours=hours)
+        end_time = self._enforce_business_hours(start_time + delta)
+        
+        # 3. Fast-forward everyone to the end of the meeting
+        for a in actors:
+            self._set_cursor(a, end_time)
+            
+        return start_time, end_time
+
+    # ── Private ───────────────────────────────────────────────────────────────
+
+    def _get_default_start(self) -> datetime:
+        """Returns 09:00 on the current State date."""
+        return self._state.current_date.replace(
+            hour=DAY_START_HOUR,
+            minute=DAY_START_MINUTE,
+            second=0,
+            microsecond=0,
+        )
+
+    def _get_cursor(self, actor: str) -> datetime:
+        """Safely fetch an actor's cursor, defaulting to 09:00 today."""
+        if actor not in self._state.actor_cursors:
+            self._state.actor_cursors[actor] = self._get_default_start()
+        return self._state.actor_cursors[actor]
+
+    def _set_cursor(self, actor: str, dt: datetime) -> None:
+        self._state.actor_cursors[actor] = dt
+
+    def _sync_time(self, actors: List[str]) -> datetime:
+        """Finds the latest cursor among actors and pulls everyone up to it."""
+        if not actors:
+            return self._get_cursor("system")
+            
+        max_time = max(self._get_cursor(a) for a in actors)
+        for a in actors:
+            self._set_cursor(a, max_time)
+            
+        return max_time
+
+    def _enforce_business_hours(self, dt: datetime) -> datetime:
+        """
+        If dt falls outside 09:00–17:30 Mon–Fri, return 09:00 the next
+        business day. Weekends are skipped.
+        """
+        end_of_day = dt.replace(
+            hour=DAY_END_HOUR,
+            minute=DAY_END_MINUTE,
+            second=0,
+            microsecond=0,
+        )
+        if dt <= end_of_day and dt.weekday() < 5:
+            return dt
+
+        # Roll forward to next business day 09:00
+        next_day = dt + timedelta(days=1)
+        while next_day.weekday() >= 5:
+            next_day += timedelta(days=1)
+
+        return next_day.replace(
+            hour=DAY_START_HOUR,
+            minute=DAY_START_MINUTE,
+            second=0,
+            microsecond=0,
+        )

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -75,11 +75,11 @@ def test_memory_context_retrieval(mock_flow):
     mem._artifacts.estimated_document_count = MagicMock(return_value=10)
     mem._artifacts.aggregate = MagicMock(return_value=[])
     mem.recall_events = MagicMock(return_value=[
-        SimEvent(type="test", day=1, date="2026-01-01", actors=[], artifact_ids={}, facts={}, summary="Test Event")
+        SimEvent(type="test", day=1, date="2026-01-01", actors=[], artifact_ids={}, facts={}, summary="Test Event", timestamp="2026-03-05T13:33:51.027Z")
     ])
 
     mock_flow._mem.recall_events.return_value = [
-        SimEvent(type="test", day=1, date="2026-01-01", actors=[], artifact_ids={}, facts={}, summary="Test Event")
+        SimEvent(type="test", day=1, date="2026-01-01", actors=[], artifact_ids={}, facts={}, summary="Test Event", timestamp="2026-03-05T13:33:51.027Z")
     ]
     
     context = mem.context_for_prompt("server crash")
@@ -141,14 +141,15 @@ def test_temporal_memory_isolation(mock_flow):
     mock_cursor.limit.return_value = iter([])
     mem._events.find = MagicMock(return_value=mock_cursor)
 
-    mem.context_for_prompt("incident", as_of_day=5)
+    mem.context_for_prompt("incident", as_of_time="2026-03-05T13:33:51.027Z")
     
     args, kwargs = mem._artifacts.aggregate.call_args
     pipeline = args[0]
     
-    # Check if $match day <= 5 exists in the pipeline
-    has_temporal_filter = any("$match" in stage and "day" in stage["$match"] for stage in pipeline)
-    assert has_temporal_filter
+    vector_search_stage = next(s for s in pipeline if "$vectorSearch" in s)
+    assert "filter" in vector_search_stage["$vectorSearch"]
+    assert "timestamp" in vector_search_stage["$vectorSearch"]["filter"]
+    assert vector_search_stage["$vectorSearch"]["filter"]["timestamp"] == {"$lte": "2026-03-05T13:33:51.027Z"}
 
 def test_graph_interaction_boost(mock_flow):
     """Verifies that Slack interactions boost edge weights between participants."""
@@ -177,7 +178,7 @@ def test_git_simulator_reviewer_selection(mock_flow):
     mock_flow.social_graph.add_edge("Alice", "Bob", weight=10.0) 
     mock_flow.social_graph.add_edge("Alice", "Charlie", weight=1.0) 
     
-    pr = mock_flow._git.create_pr(author="Alice", ticket_id="TKT-1", title="Fixing stuff")
+    pr = mock_flow._git.create_pr(author="Alice", ticket_id="TKT-1", title="Fixing stuff", timestamp="2026-03-05T13:33:51.027Z")
     
     # The simulator should automatically pick Bob as the primary reviewer
     assert pr["reviewers"][0] == "Bob"
@@ -239,7 +240,8 @@ def test_memory_log_event():
     
     event = SimEvent(
         type="test_event", day=1, date="2026-01-01", 
-        actors=["Alice"], artifact_ids={}, facts={"foo": "bar"}, summary="Test"
+        actors=["Alice"], artifact_ids={}, facts={"foo": "bar"}, summary="Test",
+        timestamp="2026-03-05T13:33:51.027Z"
     )
     
     mem.log_event(event)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -4,6 +4,8 @@ from flow import Flow, ActiveIncident
 from memory import SimEvent
 from org_lifecycle import OrgLifecycleManager, patch_validator_for_lifecycle
 
+from datetime import datetime
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # FIXTURES
@@ -17,6 +19,12 @@ def mock_flow():
         flow.state.day = 5
         flow.state.system_health = 80
         return flow
+    
+@pytest.fixture
+def mock_clock():
+    clock = MagicMock()
+    clock.schedule_meeting.return_value = datetime(2026, 1, 5, 9, 0, 0)
+    return clock
 
 
 @pytest.fixture
@@ -72,7 +80,7 @@ def lifecycle(mock_flow):
 # 1. JIRA TICKET REASSIGNMENT
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_departure_reassigns_open_tickets(lifecycle):
+def test_departure_reassigns_open_tickets(lifecycle, mock_clock):
     """
     Verifies that non-Done JIRA tickets owned by a departing engineer are
     reassigned to the dept lead and reset to 'To Do' when no PR is linked.
@@ -92,7 +100,7 @@ def test_departure_reassigns_open_tickets(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     t101 = next(t for t in state.jira_tickets if t["id"] == "ORG-101")
     t102 = next(t for t in state.jira_tickets if t["id"] == "ORG-102")
@@ -110,7 +118,7 @@ def test_departure_reassigns_open_tickets(lifecycle):
     assert t103["assignee"] == "Bob"
 
 
-def test_departure_preserves_in_progress_ticket_with_pr(lifecycle):
+def test_departure_preserves_in_progress_ticket_with_pr(lifecycle, mock_clock):
     """
     An 'In Progress' ticket that already has a linked PR must keep its status
     so the existing PR review/merge flow can close it naturally.
@@ -126,7 +134,7 @@ def test_departure_preserves_in_progress_ticket_with_pr(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "layoff", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     t200 = next(t for t in state.jira_tickets if t["id"] == "ORG-200")
     assert t200["assignee"] == "Alice"
@@ -137,7 +145,7 @@ def test_departure_preserves_in_progress_ticket_with_pr(lifecycle):
 # 2. ACTIVE INCIDENT HANDOFF
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_departure_hands_off_active_incident(lifecycle):
+def test_departure_hands_off_active_incident(lifecycle, mock_clock):
     """
     When a departing engineer owns an active incident's JIRA ticket, ownership
     must transfer to another person before the node is removed.
@@ -156,7 +164,7 @@ def test_departure_hands_off_active_incident(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     t300 = next(t for t in state.jira_tickets if t["id"] == "ORG-300")
     # Bob is gone — ticket must now belong to someone still in the graph
@@ -164,7 +172,7 @@ def test_departure_hands_off_active_incident(lifecycle):
     assert t300["assignee"] in all_names or t300["assignee"] == "Alice"
 
 
-def test_handoff_emits_escalation_chain_simevent(lifecycle):
+def test_handoff_emits_escalation_chain_simevent(lifecycle, mock_clock):
     """
     The forced handoff must emit an escalation_chain SimEvent with
     trigger='forced_handoff_on_departure' so the ground-truth log is accurate.
@@ -183,7 +191,7 @@ def test_handoff_emits_escalation_chain_simevent(lifecycle):
     dep_cfg = {"name": "Carol", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.8, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     logged_types = [call.args[0].type for call in mgr._mem.log_event.call_args_list]
     assert "escalation_chain" in logged_types
@@ -200,7 +208,7 @@ def test_handoff_emits_escalation_chain_simevent(lifecycle):
 # 3. CENTRALITY VACUUM
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_centrality_vacuum_stresses_neighbours(lifecycle):
+def test_centrality_vacuum_stresses_neighbours(lifecycle, mock_clock):
     """
     Removing a bridge shortcut node should increase stress on remaining nodes
     that absorb its rerouted traffic.
@@ -253,7 +261,7 @@ def test_centrality_vacuum_stresses_neighbours(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     stress_increased = any(
         gd_ring._stress.get(n, 0) > stress_before[n]
@@ -263,7 +271,7 @@ def test_centrality_vacuum_stresses_neighbours(lifecycle):
     assert stress_increased
 
 
-def test_centrality_vacuum_stress_capped_at_20(lifecycle):
+def test_centrality_vacuum_stress_capped_at_20(lifecycle, mock_clock):
     """
     The per-departure stress cap of 20 points must never be exceeded regardless
     of how extreme the centrality shift is.
@@ -280,7 +288,7 @@ def test_centrality_vacuum_stress_capped_at_20(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     for name in ["Alice", "Carol"]:
         if not gd.G.has_node(name):
@@ -293,7 +301,7 @@ def test_centrality_vacuum_stress_capped_at_20(lifecycle):
 # 4. NODE REMOVAL & GRAPH INTEGRITY
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_departed_node_removed_from_graph(lifecycle):
+def test_departed_node_removed_from_graph(lifecycle, mock_clock):
     """The departing engineer's node must not exist in the graph after departure."""
     mgr, gd, org_chart, all_names, state = lifecycle
     state.jira_tickets     = []
@@ -304,14 +312,14 @@ def test_departed_node_removed_from_graph(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     assert not gd.G.has_node("Bob")
     assert "Bob" not in all_names
     assert "Bob" not in org_chart.get("Engineering", [])
 
 
-def test_departed_node_stress_entry_removed(lifecycle):
+def test_departed_node_stress_entry_removed(lifecycle, mock_clock):
     """The departing engineer's stress entry must be cleaned up from GraphDynamics."""
     mgr, gd, org_chart, all_names, state = lifecycle
     state.jira_tickets     = []
@@ -322,12 +330,12 @@ def test_departed_node_stress_entry_removed(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     assert "Bob" not in gd._stress
 
 
-def test_departure_emits_employee_departed_simevent(lifecycle):
+def test_departure_emits_employee_departed_simevent(lifecycle, mock_clock):
     """A departure must emit exactly one employee_departed SimEvent."""
     mgr, gd, org_chart, all_names, state = lifecycle
     state.jira_tickets     = []
@@ -336,7 +344,7 @@ def test_departure_emits_employee_departed_simevent(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "layoff", "role": "Engineer",
                "knowledge_domains": ["auth-service"], "documented_pct": 0.2, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     departed_events = [
         call.args[0] for call in mgr._mem.log_event.call_args_list
@@ -349,7 +357,7 @@ def test_departure_emits_employee_departed_simevent(lifecycle):
     assert "auth-service" in evt.facts["knowledge_domains"]
 
 
-def test_departure_record_stored_on_state(lifecycle):
+def test_departure_record_stored_on_state(lifecycle, mock_clock):
     """state.departed_employees must be populated after a departure."""
     mgr, gd, org_chart, all_names, state = lifecycle
     state.jira_tickets     = []
@@ -358,7 +366,7 @@ def test_departure_record_stored_on_state(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Senior Engineer",
                "knowledge_domains": ["redis-cache"], "documented_pct": 0.4, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     assert "Bob" in state.departed_employees
     assert state.departed_employees["Bob"]["role"] == "Senior Engineer"
@@ -369,7 +377,7 @@ def test_departure_record_stored_on_state(lifecycle):
 # 5. KNOWLEDGE GAP SCANNING
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_knowledge_gap_scan_detects_domain_hit(lifecycle):
+def test_knowledge_gap_scan_detects_domain_hit(lifecycle, mock_clock):
     """
     scan_for_knowledge_gaps must emit a knowledge_gap_detected SimEvent when
     the incident root cause mentions a departed employee's known domain.
@@ -383,7 +391,7 @@ def test_knowledge_gap_scan_detects_domain_hit(lifecycle):
                "knowledge_domains": ["auth-service", "redis-cache"],
                "documented_pct": 0.25, "day": 3}
     mgr._scheduled_departures = {3: [dep_cfg]}
-    mgr.process_departures(day=3, date_str="2026-01-03", state=state)
+    mgr.process_departures(day=3, date_str="2026-01-03", state=state, clock=mock_clock)
     mgr._mem.log_event.reset_mock()
 
     # Now trigger a scan with text that mentions the domain
@@ -393,6 +401,7 @@ def test_knowledge_gap_scan_detects_domain_hit(lifecycle):
         day=5,
         date_str="2026-01-05",
         state=state,
+        timestamp=mock_clock
     )
 
     assert len(gaps) == 1
@@ -408,7 +417,7 @@ def test_knowledge_gap_scan_detects_domain_hit(lifecycle):
     assert len(gap_events) == 1
 
 
-def test_knowledge_gap_scan_deduplicates(lifecycle):
+def test_knowledge_gap_scan_deduplicates(lifecycle, mock_clock):
     """
     The same domain must only surface once per simulation run regardless of
     how many times the text is scanned.
@@ -420,14 +429,14 @@ def test_knowledge_gap_scan_deduplicates(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": ["redis-cache"], "documented_pct": 0.5, "day": 3}
     mgr._scheduled_departures = {3: [dep_cfg]}
-    mgr.process_departures(day=3, date_str="2026-01-03", state=state)
+    mgr.process_departures(day=3, date_str="2026-01-03", state=state, clock=mock_clock)
     mgr._mem.log_event.reset_mock()
 
     text = "redis-cache connection pool exhausted"
     mgr.scan_for_knowledge_gaps(text=text, triggered_by="ORG-401",
-                                day=5, date_str="2026-01-05", state=state)
+                                day=5, date_str="2026-01-05", state=state, timestamp=mock_clock)
     mgr.scan_for_knowledge_gaps(text=text, triggered_by="ORG-402",
-                                day=6, date_str="2026-01-06", state=state)
+                                day=6, date_str="2026-01-06", state=state, timestamp=mock_clock)
 
     gap_events = [
         call.args[0] for call in mgr._mem.log_event.call_args_list
@@ -436,7 +445,7 @@ def test_knowledge_gap_scan_deduplicates(lifecycle):
     assert len(gap_events) == 1   # second scan must be a no-op
 
 
-def test_knowledge_gap_scan_no_false_positives(lifecycle):
+def test_knowledge_gap_scan_no_false_positives(lifecycle, mock_clock):
     """Unrelated text must not trigger any knowledge gap events."""
     mgr, gd, org_chart, all_names, state = lifecycle
     state.jira_tickets     = []
@@ -445,13 +454,14 @@ def test_knowledge_gap_scan_no_false_positives(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": ["auth-service"], "documented_pct": 0.5, "day": 3}
     mgr._scheduled_departures = {3: [dep_cfg]}
-    mgr.process_departures(day=3, date_str="2026-01-03", state=state)
+    mgr.process_departures(day=3, date_str="2026-01-03", state=state, clock=mock_clock)
     mgr._mem.log_event.reset_mock()
 
     gaps = mgr.scan_for_knowledge_gaps(
         text="Disk I/O throughput degraded on worker-node-3.",
         triggered_by="ORG-403",
         day=5, date_str="2026-01-05", state=state,
+        timestamp=mock_clock
     )
     assert len(gaps) == 0
 
@@ -460,7 +470,7 @@ def test_knowledge_gap_scan_no_false_positives(lifecycle):
 # 6. NEW HIRE COLD START
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_new_hire_added_to_graph(lifecycle):
+def test_new_hire_added_to_graph(lifecycle, mock_clock):
     """A hired engineer must appear in the graph and org_chart after process_hires."""
     mgr, gd, org_chart, all_names, state = lifecycle
 
@@ -468,14 +478,14 @@ def test_new_hire_added_to_graph(lifecycle):
                 "expertise": ["Python", "Kafka"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     assert gd.G.has_node("Taylor")
     assert "Taylor" in org_chart["Engineering"]
     assert "Taylor" in all_names
 
 
-def test_new_hire_cold_start_edges(lifecycle):
+def test_new_hire_cold_start_edges(lifecycle, mock_clock):
     """
     All edges for a new hire must start at or below floor × 2, ensuring they
     sit below warmup_threshold (2.0) so the planner proposes onboarding events.
@@ -487,7 +497,7 @@ def test_new_hire_cold_start_edges(lifecycle):
                 "expertise": ["Python"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     for nb in gd.G.neighbors("Taylor"):
         weight = gd.G["Taylor"][nb]["weight"]
@@ -496,7 +506,7 @@ def test_new_hire_cold_start_edges(lifecycle):
         )
 
 
-def test_new_hire_warm_up_edge(lifecycle):
+def test_new_hire_warm_up_edge(lifecycle, mock_clock):
     """warm_up_edge must increase the edge weight between the hire and a colleague."""
     mgr, gd, org_chart, all_names, state = lifecycle
 
@@ -504,7 +514,7 @@ def test_new_hire_warm_up_edge(lifecycle):
                 "expertise": ["Python"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     weight_before = gd.G["Taylor"]["Alice"]["weight"]
     mgr.warm_up_edge("Taylor", "Alice", boost=1.5)
@@ -513,7 +523,7 @@ def test_new_hire_warm_up_edge(lifecycle):
     assert weight_after == round(weight_before + 1.5, 4)
 
 
-def test_new_hire_emits_simevent(lifecycle):
+def test_new_hire_emits_simevent(lifecycle, mock_clock):
     """process_hires must emit an employee_hired SimEvent with correct facts."""
     mgr, gd, org_chart, all_names, state = lifecycle
 
@@ -521,7 +531,7 @@ def test_new_hire_emits_simevent(lifecycle):
                 "expertise": ["Python", "Kafka"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     hired_events = [
         call.args[0] for call in mgr._mem.log_event.call_args_list
@@ -534,7 +544,7 @@ def test_new_hire_emits_simevent(lifecycle):
     assert "Kafka" in evt.facts["expertise"]
 
 
-def test_new_hire_stress_initialised_low(lifecycle):
+def test_new_hire_stress_initialised_low(lifecycle, mock_clock):
     """New hires must start with a low stress score, not inherit the org average."""
     mgr, gd, org_chart, all_names, state = lifecycle
 
@@ -542,12 +552,12 @@ def test_new_hire_stress_initialised_low(lifecycle):
                 "expertise": ["Python"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     assert gd._stress.get("Taylor", 0) == 20
 
 
-def test_new_hire_record_stored_on_state(lifecycle):
+def test_new_hire_record_stored_on_state(lifecycle, mock_clock):
     """state.new_hires must be populated with the hire's metadata."""
     mgr, gd, org_chart, all_names, state = lifecycle
 
@@ -555,7 +565,7 @@ def test_new_hire_record_stored_on_state(lifecycle):
                 "expertise": ["Python"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     assert hasattr(state, "new_hires")
     assert "Taylor" in state.new_hires
@@ -566,7 +576,7 @@ def test_new_hire_record_stored_on_state(lifecycle):
 # 7. VALIDATOR PATCH
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_patch_validator_removes_departed_actor(lifecycle):
+def test_patch_validator_removes_departed_actor(lifecycle, mock_clock):
     """
     After a departure, patch_validator_for_lifecycle must remove the departed
     name from PlanValidator._valid_actors so the actor integrity check holds.
@@ -587,14 +597,14 @@ def test_patch_validator_removes_departed_actor(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": [], "documented_pct": 0.5, "day": 5}
     mgr._scheduled_departures = {5: [dep_cfg]}
-    mgr.process_departures(day=5, date_str="2026-01-05", state=state)
+    mgr.process_departures(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     patch_validator_for_lifecycle(validator, mgr)
 
     assert "Bob" not in validator._valid_actors
 
 
-def test_patch_validator_adds_new_hire(lifecycle):
+def test_patch_validator_adds_new_hire(lifecycle, mock_clock):
     """
     After a hire, patch_validator_for_lifecycle must add the new name to
     PlanValidator._valid_actors so the planner can propose events with them.
@@ -614,7 +624,7 @@ def test_patch_validator_adds_new_hire(lifecycle):
                 "expertise": ["Python"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     patch_validator_for_lifecycle(validator, mgr)
 
@@ -625,7 +635,7 @@ def test_patch_validator_adds_new_hire(lifecycle):
 # 8. ROSTER CONTEXT
 # ─────────────────────────────────────────────────────────────────────────────
 
-def test_get_roster_context_reflects_departure_and_hire(lifecycle):
+def test_get_roster_context_reflects_departure_and_hire(lifecycle, mock_clock):
     """
     get_roster_context must surface both a recent departure and a recent hire
     so DepartmentPlanner prompts reflect actual roster state.
@@ -637,13 +647,13 @@ def test_get_roster_context_reflects_departure_and_hire(lifecycle):
     dep_cfg = {"name": "Bob", "reason": "voluntary", "role": "Engineer",
                "knowledge_domains": ["redis-cache"], "documented_pct": 0.3, "day": 4}
     mgr._scheduled_departures = {4: [dep_cfg]}
-    mgr.process_departures(day=4, date_str="2026-01-04", state=state)
+    mgr.process_departures(day=4, date_str="2026-01-04", state=state, clock=mock_clock)
 
     hire_cfg = {"name": "Taylor", "dept": "Engineering", "role": "Backend Engineer",
                 "expertise": ["Python"], "style": "methodical", "tenure": "new",
                 "day": 5}
     mgr._scheduled_hires = {5: [hire_cfg]}
-    mgr.process_hires(day=5, date_str="2026-01-05", state=state)
+    mgr.process_hires(day=5, date_str="2026-01-05", state=state, clock=mock_clock)
 
     context = mgr.get_roster_context()
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -77,7 +77,8 @@ def test_simevent_serialization():
         artifact_ids={"jira": "ORG-105", "pr": "PR-100"}, 
         facts={"duration_days": 2, "root_cause": "DNS failure"}, 
         summary="Alice fixed the DNS", 
-        tags=["incident", "p1"]
+        tags=["incident", "p1"],
+        timestamp="2026-03-05T13:33:51.027Z"
     )
     
     # Simulate saving to DB and reading back


### PR DESCRIPTION
## Fix forensic timeline integrity via actor-local simulation clock

### Problem
All artifact timestamps across Slack threads, JIRA comments, Confluence pages, and bot alerts were generated with independent `random.randint(hour, ...)` calls. This produced causally inconsistent timelines — a PagerDuty alert could be stamped after the Slack thread responding to it, and a single engineer could appear to do two things simultaneously.

### Solution
Introduces `sim_clock.py`, an actor-local clock where every employee has an independent time cursor. Timestamps are no longer randomized — they are derived from cursor state.

**Two core primitives:**
- `advance_actor()` — ambient parallel work (tickets, Confluence, deep work). Advances one cursor, samples a random artifact timestamp from within the work block. Other actors unaffected.
- `sync_and_tick()` — causal chains (incidents, Slack threads, PR reviews). Syncs all participants to the latest cursor among them, then ticks forward. Guarantees no response can be stamped before its trigger.

**Supporting methods:** `tick_message()` for per-message Slack cadence, `tick_system()` for independent bot alerts, `sync_to_system()` for incident response, `at()` and `schedule_meeting()` for ceremonies.

### Impact
- Forensic timelines are now causally correct across all artifact types
- Parallel workday activity is preserved — engineers work simultaneously, not in sequence
- Grounds `as_of_time` temporal filtering in `context_for_prompt`, closing the same-day time-travel gap that `as_of_day` alone could not prevent

See CHANGELOG v0.3.4 for full details.