### PR TITLE
prevent duplicate work on tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [v0.3.9] — 2026-03-06
+
+### Fixed
+
+- **Duplicate ticket work (`day_planner.py`)**: `_parse_plan()` now maintains a
+  `claimed_tickets` set across all engineer plans in a single planning pass.
+  Any `ticket_progress` agenda item referencing a ticket ID already claimed by
+  another engineer is stripped before execution, preventing multiple agents from
+  independently logging progress on the same ticket on the same day. Violations
+  are logged as warnings.
+- **`_validator` attribute error (`flow.py`)**: `daily_cycle` was referencing
+  `self._day_planner.validator` instead of `self._day_planner._validator`,
+  causing an `AttributeError` on day 11 when `patch_validator_for_lifecycle`
+  was first invoked.
+
+### Changed
+
+- **Ticket dedup safety net (`plan_validator.py`, `normal_day.py`)**: Added a
+  secondary `ticket_actors_today` guard on `state` that tracks which actors have
+  executed `ticket_progress` against a given ticket ID within the current day.
+  The validator checks this before approving `ProposedEvent` entries via
+  `facts_hint["ticket_id"]`, and `_handle_ticket_progress` registers the actor
+  on success. Resets to `{}` at the top of each `daily_cycle()`. Acts as a
+  catch-all for paths that bypass `_parse_plan`.
+
+---
+
 ## [v0.3.8] — 2026-03-06
 
 ### Added

--- a/src/day_planner.py
+++ b/src/day_planner.py
@@ -88,9 +88,6 @@ class DepartmentPlanner:
 
     {lifecycle_context}
 
-    KNOWN EVENT TYPES YOU CAN PROPOSE:
-    {known_types}
-
     You may also propose NEW event types if the situation genuinely calls for it.
     If you propose a novel event, set "is_novel": true and specify "artifact_hint"
     as one of: "slack", "jira", "confluence", or "email".
@@ -99,10 +96,7 @@ class DepartmentPlanner:
     1. Write a department theme for today (one sentence, specific to {dept}).
     2. For each team member, write a 2-4 item agenda (what they plan to work on).
        CRITICAL RULES:
-       - ROLE ENFORCEMENT: If {dept} is a non-engineering department (like HR, Sales, Marketing), your team members CANNOT 
-         write code, design system architecture, or review PRs. Their agenda MUST reflect their actual business functions (e.g., recruitment, 
-         policy updates, sales calls), even if the ORG THEME is highly technical.
-       - TICKET ALLOCATION: Do not assign multiple people to the same ticket ID for "ticket_progress". Only the explicit assignee should make progress.
+       - NON-ENGINEERING TEAMS: Agenda items must reflect actual business functions only (recruitment, sales calls, policy — not code or PRs).
        - EVENT REDUNDANCY: Do not schedule redundant "design_discussion" or "async_question" events for the same topic across multiple people. 
          One initiator is enough.
     3. Propose 1-3 events that should fire today, ordered by priority (1=must, 3=optional).
@@ -140,8 +134,7 @@ class DepartmentPlanner:
         "is_novel": false,
         "artifact_hint": "string or null"
         }}
-    ],
-    "planner_reasoning": "string"
+    ]
     }}
     """
 
@@ -250,22 +243,40 @@ class DepartmentPlanner:
             return self._fallback_plan(org_theme, day, date, cross_signals)
 
         # ── Engineer plans ────────────────────────────────────────────────────
+        # Tracks which ticket IDs have already been claimed for ticket_progress
+        # this planning pass. Prevents the LLM assigning the same ticket to
+        # multiple engineers despite the prompt instruction to the contrary.
+        claimed_tickets: set = set()
+
         eng_plans: List[EngineerDayPlan] = []
         for ep in data.get("engineer_plans", []):
             name = ep.get("name", "")
             if name not in self.members:
                 continue   # LLM invented a name — skip silently
 
-            agenda = [
-                AgendaItem(
-                    activity_type=a.get("activity_type", "ticket_progress"),
+            agenda = []
+            for a in ep.get("agenda", []):
+                activity_type = a.get("activity_type", "ticket_progress")
+                related_id    = a.get("related_id")
+
+                # Strip duplicate ticket_progress items — only the first engineer
+                # to claim a ticket ID in this plan gets to work on it.
+                if activity_type == "ticket_progress" and related_id:
+                    if related_id in claimed_tickets:
+                        logger.warning(
+                            f"[planner] {self.dept}: stripped duplicate "
+                            f"ticket_progress for {related_id} from {name}'s agenda."
+                        )
+                        continue
+                    claimed_tickets.add(related_id)
+
+                agenda.append(AgendaItem(
+                    activity_type=activity_type,
                     description=a.get("description", ""),
-                    related_id=a.get("related_id"),
+                    related_id=related_id,
                     collaborator=_coerce_collaborators(a.get("collaborator")),
                     estimated_hrs=float(a.get("estimated_hrs", 2.0)),
-                )
-                for a in ep.get("agenda", [])
-            ]
+                ))
 
             # Fallback agenda if LLM returned nothing useful
             if not agenda:
@@ -455,20 +466,6 @@ class OrgCoordinator:
 
     ORG STATE: health={health}, morale={morale_label}
 
-    A collision event is something like:
-    - Sales heard about an incident and needs a stability update from Engineering
-    - A customer escalation lands in Sales that Engineering needs to know about
-    - HR notices two burnt-out engineers and schedules a sync with the Eng lead
-    - A feature request from Sales creates a new JIRA ticket in Engineering's backlog
-
-    CRITICAL RULES:
-    1. STRICT ROLES: Non-engineering roles (Sales, HR) can ask for updates, escalate customer issues, 
-       or check on employee well-being, but they CANNOT solve technical problems, write code, or propose system architecture.
-    2. ACTOR MATCHING: The 'actors' array MUST contain real names selected from the specific department 
-       lists provided above. Do not invent names.
-    3. BE CONSERVATIVE: LLMs often want to force connections. Only propose a collision if it is highly organic and essential. 
-       If nothing truly connects today, you MUST respond with {{"collision": null}}.
-
     Respond ONLY with valid JSON:
     {{
     "collision": {{
@@ -478,8 +475,7 @@ class OrgCoordinator:
         "facts_hint": {{}},
         "priority": 1,
         "artifact_hint": "string"
-    }},
-    "reasoning": "string"
+    }}
     }}
     """
 

--- a/src/flow.py
+++ b/src/flow.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 from typing import Any, List, Dict, Optional
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from dataclasses import field
 
 from day_planner import DayPlannerOrchestrator
 from normal_day import NormalDayHandler
@@ -280,6 +281,7 @@ class State(BaseModel):
     daily_event_type_counts: Dict[str, int] = {}
     departed_employees: Dict[str, Dict] = {}   # name → {left, role, knew_about, documented_pct}
     new_hires: Dict[str, Dict] = {}   # name → {joined, role, dept, expertise}
+    ticket_actors_today: Dict[str, List[str]] = field(default_factory=dict)
 
 
 # ─────────────────────────────────────────────
@@ -610,6 +612,7 @@ class Flow(Flow[State]):
                 self.state.current_date += timedelta(days=1)
                 continue
 
+            self._state.ticket_actors_today = {}
             self._clock.reset_to_business_start(ALL_NAMES)
             date_str = str(self.state.current_date.date())
             departures = self._lifecycle.process_departures(self.state.day, date_str, self.state, self._clock)
@@ -617,7 +620,7 @@ class Flow(Flow[State]):
 
             if departures or hires:
                 # Patch the day planner's validator to reflect the new roster
-                patch_validator_for_lifecycle(self._day_planner.validator, self._lifecycle)
+                patch_validator_for_lifecycle(self._day_planner._validator, self._lifecycle)
 
             org_plan = self._day_planner.plan(
                 self.state, self._mem, self.graph_dynamics,

--- a/src/normal_day.py
+++ b/src/normal_day.py
@@ -302,6 +302,9 @@ class NormalDayHandler:
             tags=["jira", "engineering"]
         ))
 
+        bucket = self._state.ticket_actors_today.setdefault(ticket_id, set())
+        bucket.add(assignee)
+
         generated_artifacts = [ticket_id]
         if spawned_pr_id is not None:
             generated_artifacts.append(spawned_pr_id)

--- a/src/plan_validator.py
+++ b/src/plan_validator.py
@@ -11,6 +11,8 @@ Checks every ProposedEvent against:
   3. State plausibility — health/morale thresholds make the event sensible
   4. Cooldown windows   — same event type can't fire too frequently
   5. Novel event triage — unknown event types are logged, not silently dropped
+  6. Ticket dedup       — same ticket can't receive progress from multiple actors
+                          on the same day (reads state.ticket_actors_today)
 """
 
 from __future__ import annotations
@@ -100,6 +102,10 @@ class PlanValidator:
         recent_incident_count = sum(
             e.get("incidents_opened", 0) for e in recent_events
         )
+        # Live per-ticket actor tracking for today — read from state, not summaries.
+        # state.ticket_actors_today is populated by flow.py as ticket_progress
+        # events execute, and reset to {} at the top of each daily_cycle().
+        ticket_actors_today = self._ticket_actors_today(state)
 
         results: List[ValidationResult] = []
         for event in proposed:
@@ -108,6 +114,7 @@ class PlanValidator:
                 state,
                 recent_event_types,
                 recent_incident_count,
+                ticket_actors_today,
             )
             if not result.approved and result.was_novel:
                 self._novel_log.append(event)
@@ -137,10 +144,11 @@ class PlanValidator:
 
     def _validate_one(
         self,
-        event:                ProposedEvent,
+        event:                 ProposedEvent,
         state,
-        recent_event_types:   Dict[str, int],   # {event_type: days_since_last}
+        recent_event_types:    Dict[str, int],   # {event_type: days_since_last}
         recent_incident_count: int,
+        ticket_actors_today:   Dict[str, set],   # {ticket_id: {actors who touched it today}}
     ) -> ValidationResult:
 
         # ── 1. Actor integrity ────────────────────────────────────────────────
@@ -151,7 +159,7 @@ class PlanValidator:
                 rejection_reason=f"Unknown actors: {unknown_actors}. "
                                  f"LLM invented names not in org_chart.",
             )
-        
+
         # ── 1b. Departed-actor guard ──────────────────────────────────────────
         # patch_validator_for_lifecycle() keeps _valid_actors pruned,
         # but this explicit check gives a clearer rejection message.
@@ -229,6 +237,24 @@ class PlanValidator:
                 ),
             )
 
+        # ── 6. Ticket dedup ───────────────────────────────────────────────────
+        # Prevents multiple agents independently logging progress on the same
+        # ticket on the same day. ticket_id is sourced from facts_hint, not
+        # related_id (which lives on AgendaItem, not ProposedEvent).
+        if event.event_type == "ticket_progress":
+            ticket_id = event.facts_hint.get("ticket_id")
+            if ticket_id:
+                actors_on_ticket = ticket_actors_today.get(ticket_id, set())
+                overlap = [a for a in event.actors if a in actors_on_ticket]
+                if overlap:
+                    return ValidationResult(
+                        approved=False, event=event,
+                        rejection_reason=(
+                            f"Duplicate ticket work: {overlap} already logged "
+                            f"progress on {ticket_id} today."
+                        ),
+                    )
+
         # ── All checks passed ─────────────────────────────────────────────────
         return ValidationResult(approved=True, event=event)
 
@@ -250,3 +276,13 @@ class PlanValidator:
                 if etype not in days_since:
                     days_since[etype] = i + 1
         return days_since
+
+    def _ticket_actors_today(self, state) -> Dict[str, set]:
+        """
+        Returns the live {ticket_id: {actor, ...}} map for today.
+        Reads from state.ticket_actors_today, which flow.py owns:
+          - Reset to {} at the top of each daily_cycle()
+          - Updated after each ticket_progress event fires
+        Defaults to {} safely if state doesn't have the attribute yet.
+        """
+        return getattr(state, "ticket_actors_today", {})


### PR DESCRIPTION
## [v0.3.9] — 2026-03-06

### Fixed

- **Duplicate ticket work (`day_planner.py`)**: `_parse_plan()` now maintains a
  `claimed_tickets` set across all engineer plans in a single planning pass.
  Any `ticket_progress` agenda item referencing a ticket ID already claimed by
  another engineer is stripped before execution, preventing multiple agents from
  independently logging progress on the same ticket on the same day. Violations
  are logged as warnings.
- **`_validator` attribute error (`flow.py`)**: `daily_cycle` was referencing
  `self._day_planner.validator` instead of `self._day_planner._validator`,
  causing an `AttributeError` on day 11 when `patch_validator_for_lifecycle`
  was first invoked.

### Changed

- **Ticket dedup safety net (`plan_validator.py`, `normal_day.py`)**: Added a
  secondary `ticket_actors_today` guard on `state` that tracks which actors have
  executed `ticket_progress` against a given ticket ID within the current day.
  The validator checks this before approving `ProposedEvent` entries via
  `facts_hint["ticket_id"]`, and `_handle_ticket_progress` registers the actor
  on success. Resets to `{}` at the top of each `daily_cycle()`. Acts as a
  catch-all for paths that bypass `_parse_plan`.